### PR TITLE
Fix naming and scaling inconsistencies on the Network bits/sec chart

### DIFF
--- a/CollectD/Page_Memcached.json
+++ b/CollectD/Page_Memcached.json
@@ -1309,7 +1309,7 @@
 }, {
   "marshallId" : 13,
   "marshallMemberOf" : [ 3 ],
-  "sf_chart" : "Network bits/sec",
+  "sf_chart" : "Network Bits/sec",
   "sf_chartIndex" : 1440941057408,
   "sf_jobMaxDelay" : 0,
   "sf_jobResolution" : 1000,
@@ -1397,7 +1397,9 @@
           "type" : "aggregation"
         },
         "fn" : {
-          "options" : { },
+          "options" : {
+            "scaleAmount" : 8
+          },
           "type" : "SCALE"
         },
         "showMe" : false


### PR DESCRIPTION
Capitalize the "B" in "bits" to match elsewhere
Fix scaling of memcached_octets.rx