### PR TITLE
remove spurious usages of aws properties in discovery selectors

### DIFF
--- a/AWS/Page_AWS EC2.json
+++ b/AWS/Page_AWS EC2.json
@@ -1878,7 +1878,7 @@
     } ],
     "version" : 1
   },
-  "sf_discoverySelectors" : [ "_exists_:aws_region", "_exists_:aws_availability_zone", "sf_key:host", "namespace:AWS/EC2", "_exists_:aws_instance_type", "sf_key:InstanceId" ],
+  "sf_discoverySelectors" : [ "sf_key:host", "namespace:AWS/EC2", "sf_key:InstanceId" ],
   "sf_description" : "",
   "sf_type" : "Dashboard",
   "sf_discoveryQuery" : "namespace:\"AWS/EC2\" AND _exists_:InstanceId",

--- a/CollectD/Page_Apache.json
+++ b/CollectD/Page_Apache.json
@@ -1001,7 +1001,7 @@
   "sf_dashboard" : "Apache Web Servers",
   "sf_description" : "",
   "sf_discoveryQuery" : "plugin:apache",
-  "sf_discoverySelectors" : [ "sf_hostHasService:apache", "plugin:apache", "_exists_:aws_region", "_exists_:aws_availability_zone", "_exists_:aws_instance_type" ],
+  "sf_discoverySelectors" : [ "plugin:apache" ],
   "sf_type" : "Dashboard",
   "sf_uiModel" : {
     "version" : 1,

--- a/CollectD/Page_Cassandra.json
+++ b/CollectD/Page_Cassandra.json
@@ -232,10 +232,7 @@
         "sf_discoveryQuery": "hostHasService:cassandra",
         "sf_discoverySelectors": [
             "sf_hostHasService:cassandra",
-            "_exists_:aws_region",
-            "_exists_:aws_availability_zone",
-            "hostHasService:cassandra",
-            "_exists_:aws_instance_type"
+            "hostHasService:cassandra"
         ],
         "sf_type": "Dashboard",
         "marshallMemberOf": [

--- a/CollectD/Page_CollectD_SFX.json
+++ b/CollectD/Page_CollectD_SFX.json
@@ -2175,7 +2175,7 @@
   "sf_dashboard" : "collectd (a)",
   "sf_description" : "",
   "sf_discoveryQuery" : "plugin:signalfx-metadata AND sf_metric:cpu.utilization AND _missing_:agent",
-  "sf_discoverySelectors" : [ "_missing_:agent", "_exists_:aws_region", "_exists_:aws_availability_zone", "sf_key:host", "_exists_:aws_instance_type" ],
+  "sf_discoverySelectors" : [ "_missing_:agent", "sf_key:host" ],
   "sf_type" : "Dashboard",
   "sf_uiModel" : {
     "version" : 1,

--- a/CollectD/Page_Docker.json
+++ b/CollectD/Page_Docker.json
@@ -2167,7 +2167,7 @@
   "sf_dashboard" : "Docker Hosts",
   "sf_description" : "Real-time statistics about all running Docker containers in your infrastructure.",
   "sf_discoveryQuery" : "plugin:docker",
-  "sf_discoverySelectors" : [ "_exists_:aws_region", "plugin:docker", "_exists_:aws_availability_zone", "sf_hostHasService:docker", "namespace:AWS/EC2", "_exists_:aws_instance_type" ],
+  "sf_discoverySelectors" : [ "plugin:docker", "sf_hostHasService:docker" ],
   "sf_type" : "Dashboard",
   "sf_uiModel" : {
     "version" : 1,

--- a/CollectD/Page_Kafka.json
+++ b/CollectD/Page_Kafka.json
@@ -222,9 +222,6 @@
         "sf_discoveryQuery": "sf_hostHasService:kafka", 
         "sf_discoverySelectors": [
             "sf_hostHasService:kafka", 
-            "_exists_:aws_region", 
-            "_exists_:aws_availability_zone", 
-            "_exists_:aws_instance_type",
             "sf_key:host"
         ], 
         "sf_type": "Dashboard", 

--- a/CollectD/Page_Memcached.json
+++ b/CollectD/Page_Memcached.json
@@ -17,7 +17,7 @@
   "sf_dashboard" : "Memcached (a)",
   "sf_description" : "",
   "sf_discoveryQuery" : "plugin:memcached",
-  "sf_discoverySelectors" : [ "_exist_:aws_availability_zone", "plugin:memcached", "_exists_:aws_region", "sf_hostHasService:memcached", "_exists_:aws_instance_type" ],
+  "sf_discoverySelectors" : [ "plugin:memcached", "sf_hostHasService:memcached" ],
   "sf_type" : "Dashboard",
   "sf_uiModel" : {
     "version" : 1,

--- a/CollectD/Page_MongoDB.json
+++ b/CollectD/Page_MongoDB.json
@@ -260,9 +260,6 @@
         "sf_discoveryQuery": "plugin:mongo",
         "sf_discoverySelectors": [
             "plugin:mongo",
-            "_exists_:aws_region",
-            "_exists_:aws_availability_zone",
-            "_exists_:aws_instance_type",
             "sf_hostHasService:mongo"
         ],
         "sf_type": "Dashboard",

--- a/CollectD/Page_MySQL.json
+++ b/CollectD/Page_MySQL.json
@@ -1880,10 +1880,7 @@
         "sf_description": "",
         "sf_discoveryQuery": "plugin:mysql",
         "sf_discoverySelectors": [
-            "_exists_:aws_region",
-            "_exists_:aws_availability_zone",
             "sf_hostHasService:mysql",
-            "_exists_:aws_instance_type",
             "plugin:mysql"
         ],
         "sf_type": "Dashboard",

--- a/CollectD/Page_Nginx.json
+++ b/CollectD/Page_Nginx.json
@@ -25,10 +25,7 @@
         "sf_dashboard": "NGINX Servers",
         "sf_discoveryQuery": "plugin:nginx",
         "sf_discoverySelectors": [
-            "_exists_:aws_region",
-            "_exists_:aws_availability_zone",
             "sf_hostHasService:nginx",
-            "_exists_:aws_instance_type",
             "plugin:nginx"
         ],
         "sf_type": "Dashboard",

--- a/CollectD/Page_PostgreSQL.json
+++ b/CollectD/Page_PostgreSQL.json
@@ -1985,10 +1985,7 @@
         "sf_discoveryQuery": "plugin:postgresql",
         "sf_discoverySelectors": [
             "plugin:postgresql",
-            "sf_hostHasService:postgresql",
-            "_exists_:aws_region",
-            "_exists_:aws_availability_zone",
-            "_exists_:aws_instance_type"
+            "sf_hostHasService:postgresql"
         ],
         "sf_type": "Dashboard",
         "marshallMemberOf": [

--- a/CollectD/Page_Redis.json
+++ b/CollectD/Page_Redis.json
@@ -1769,10 +1769,7 @@
         "sf_discoveryQuery": "plugin:redis_info",
         "sf_discoverySelectors": [
             "plugin:redis_info",
-            "_exists_:aws_region",
             "_exists_:host",
-            "_exists_:aws_availability_zone",
-            "_exists_:aws_instance_type",
             "sf_hostHasService:redis_info"
         ],
         "sf_type": "Dashboard",

--- a/CollectD/Page_Varnish.json
+++ b/CollectD/Page_Varnish.json
@@ -2306,7 +2306,7 @@
   "sf_dashboard" : "Varnish (a)",
   "sf_description" : "Multiple varnish servers",
   "sf_discoveryQuery" : "plugin:varnish",
-  "sf_discoverySelectors" : [ "_exists_:aws_region", "sf_hostHasService:varnish", "_exists_:aws_availability_zone", "_exists_:aws_instance_type", "plugin:varnish" ],
+  "sf_discoverySelectors" : [ "sf_hostHasService:varnish", "plugin:varnish" ],
   "sf_type" : "Dashboard",
   "sf_uiModel" : {
     "version" : 1,

--- a/CollectD/Page_Zookeeper.json
+++ b/CollectD/Page_Zookeeper.json
@@ -232,10 +232,7 @@
         "sf_discoverySelectors": [
             "plugin:zookeeper",
             "sf_hostHasService:zookeeper",
-            "_exists_:aws_region",
-            "_exists_:aws_availability_zone",
-            "hostHasService:zookeeper",
-            "_exists_:aws_instance_type"
+            "hostHasService:zookeeper"
         ],
         "sf_type": "Dashboard",
         "marshallMemberOf": [

--- a/Telegraf/Page_Infrastructure_Telegraf.json
+++ b/Telegraf/Page_Infrastructure_Telegraf.json
@@ -2293,7 +2293,7 @@
   "sf_dashboard" : "telegraf (a)",
   "sf_description" : "Dashboards about infrastructure as measured by Telegraf.",
   "sf_discoveryQuery" : "plugin:signalfx-metadata AND sf_metric:cpu.utilization AND agent:telegraf",
-  "sf_discoverySelectors" : [ "agent:telegraf", "_exists_:aws_region", "_exists_:aws_availability_zone", "sf_key:host", "_exists_:aws_instance_type" ],
+  "sf_discoverySelectors" : [ "agent:telegraf", "sf_key:host" ],
   "sf_savedFilters" : {
     "density" : null,
     "sources" : null,


### PR DESCRIPTION
There appear to be spurious usages of exists:aws_x throughout Page-Imports which could result in SD dashboards not showing up 1)ever, if not on amazon 2) until tag sync is turned on.
