### PR TITLE
Use CPUReservation to show count of number of clusters in ECS

### DIFF
--- a/AWS/Page_AWS ECS.json
+++ b/AWS/Page_AWS ECS.json
@@ -3338,35 +3338,17 @@
     "chartType" : "line",
     "allPlots" : [ {
       "queryItems" : [ {
-        "iconClass" : "icon-properties",
-        "value" : "AWS/ECS",
-        "propertyValue" : "AWS/ECS",
         "NOT" : false,
-        "query" : "namespace:\"AWS/ECS\"",
+        "iconClass" : "icon-properties",
         "property" : "namespace",
-        "type" : "property"
-      },{
-        "iconClass" : "icon-properties",
-        "value" : "mean",
-        "propertyValue" : "mean",
-        "NOT" : false,
-        "query" : "stat:mean",
-        "property" : "stat",
-        "type" : "property"
-      }, {
-        "iconClass" : "icon-properties",
-        "value" : "*",
-        "propertyValue" : "*",
-        "key" : "ServiceName",
-        "query" : "ServiceName:*",
-        "property" : "ServiceName",
-        "NOT": true,
-        "type" : "property"
+        "propertyValue" : "AWS/ECS",
+        "type" : "property",
+        "value" : "AWS/ECS"
       } ],
       "uniqueKey" : 1,
       "name" : "",
       "seriesData" : {
-        "metric" : "CPUUtilization"
+        "metric" : "CPUReservation"
       },
       "dataManipulations" : [ {
         "direction" : {


### PR DESCRIPTION
Need to use this metric in order to get the dashboard to show under system metrics
for ECS in the infra nav, which now relies on the mtsQuery field of infra nav
mode definitions.