### PR TITLE
Use last value extrapolation on kong db reachable

### DIFF
--- a/CollectD/Page_Kong.json
+++ b/CollectD/Page_Kong.json
@@ -5604,7 +5604,7 @@
     }, {
       "configuration" : {
         "aliases" : { },
-        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
+        "extrapolationPolicy" : "LAST_VALUE_EXTRAPOLATION",
         "maxExtrapolations" : -1
       },
       "dataManipulations" : [ ],
@@ -11984,7 +11984,7 @@
     }, {
       "configuration" : {
         "aliases" : { },
-        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
+        "extrapolationPolicy" : "LAST_VALUE_EXTRAPOLATION",
         "maxExtrapolations" : -1
       },
       "dataManipulations" : [ ],


### PR DESCRIPTION
Presents incorrect outage w/ datapoint jitter otherwise.