### PR TITLE
Add exclusions to Kong hourly handled responses

### DIFF
--- a/CollectD/Page_Kong.json
+++ b/CollectD/Page_Kong.json
@@ -473,114 +473,6 @@
 }, {
   "marshallId" : 4,
   "marshallMemberOf" : [ 2 ],
-  "sf_chart" : "Responses / Second",
-  "sf_chartIndex" : 1528134810674,
-  "sf_description" : "Rate of Service responses",
-  "sf_type" : "Chart",
-  "sf_uiModel" : {
-    "allPlots" : [ {
-      "_originalLabel" : "A",
-      "configuration" : {
-        "aliases" : { },
-        "colorOverride" : "#0077c2",
-        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
-        "maxExtrapolations" : -1,
-        "prefix" : "",
-        "suffix" : "",
-        "unitType" : null
-      },
-      "dataManipulations" : [ {
-        "direction" : {
-          "options" : {
-            "aggregateGroupBy" : [ ],
-            "collapseGroups" : false,
-            "transformTimeRange" : null
-          },
-          "type" : "aggregation"
-        },
-        "fn" : {
-          "options" : { },
-          "type" : "SUM"
-        },
-        "showMe" : false
-      } ],
-      "invisible" : false,
-      "name" : "responses",
-      "queryItems" : [ {
-        "NOT" : false,
-        "iconClass" : "sf-icon-property",
-        "property" : "plugin",
-        "propertyValue" : "kong",
-        "query" : "plugin:\"kong\"",
-        "type" : "property",
-        "value" : "kong"
-      }, {
-        "NOT" : false,
-        "iconClass" : "icon-properties",
-        "property" : "service_name",
-        "propertyValue" : "*",
-        "type" : "property",
-        "value" : "*"
-      } ],
-      "seriesData" : {
-        "metric" : "counter.kong.responses.count"
-      },
-      "transient" : false,
-      "type" : "plot",
-      "uniqueKey" : 1,
-      "yAxisIndex" : 0
-    }, {
-      "configuration" : {
-        "aliases" : { },
-        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
-        "maxExtrapolations" : -1
-      },
-      "dataManipulations" : [ ],
-      "invisible" : false,
-      "metricDefinition" : { },
-      "name" : "New Plot",
-      "queryItems" : [ ],
-      "seriesData" : { },
-      "transient" : true,
-      "type" : "plot",
-      "uniqueKey" : 2,
-      "yAxisIndex" : 0
-    } ],
-    "chartMode" : "single",
-    "chartType" : "line",
-    "chartconfig" : {
-      "absoluteEnd" : null,
-      "absoluteStart" : null,
-      "colorByMetric" : false,
-      "colorByValue" : false,
-      "colorByValueScale" : [ ],
-      "hideTimestamp" : false,
-      "histogramColor" : "#ea1849",
-      "maxDecimalPlaces" : 2,
-      "range" : -1800000,
-      "rangeEnd" : 0,
-      "secondaryVisualization" : "NONE",
-      "sortPreference" : "",
-      "useKMG2" : false,
-      "yAxisConfigurations" : [ {
-        "id" : "yAxis0",
-        "max" : null,
-        "min" : null,
-        "name" : "yAxis0",
-        "plotlines" : {
-          "high" : null,
-          "low" : null
-        }
-      } ]
-    },
-    "currentUniqueKey" : 3,
-    "relatedDetectors" : [ ],
-    "revisionNumber" : 19,
-    "uiHelperValue" : "##CHARTID##_19"
-  }
-}, {
-  "marshallId" : 5,
-  "marshallMemberOf" : [ 2 ],
   "sf_chart" : "Responses by Status Code",
   "sf_chartIndex" : 1528136271804,
   "sf_description" : "Number of responses per interval by status code group",
@@ -941,30 +833,28 @@
     "uiHelperValue" : "##CHARTID##_24"
   }
 }, {
-  "marshallId" : 6,
+  "marshallId" : 5,
   "marshallMemberOf" : [ 2 ],
-  "sf_chart" : "Requests by HTTP Method",
-  "sf_chartIndex" : 1528138165800,
-  "sf_description" : "Number of Service-fielded requests per interval by HTTP method",
+  "sf_chart" : "Responses / Second",
+  "sf_chartIndex" : 1528134810674,
+  "sf_description" : "Rate of Service responses",
   "sf_type" : "Chart",
   "sf_uiModel" : {
     "allPlots" : [ {
       "_originalLabel" : "A",
       "configuration" : {
         "aliases" : { },
-        "colorOverride" : null,
+        "colorOverride" : "#0077c2",
         "extrapolationPolicy" : "NULL_EXTRAPOLATION",
         "maxExtrapolations" : -1,
-        "rollupPolicy" : "DELTA_ROLLUP",
-        "suffix" : "requests",
+        "prefix" : "",
+        "suffix" : "",
         "unitType" : null
       },
       "dataManipulations" : [ {
         "direction" : {
           "options" : {
-            "aggregateGroupBy" : [ {
-              "value" : "http_method"
-            } ],
+            "aggregateGroupBy" : [ ],
             "collapseGroups" : false,
             "transformTimeRange" : null
           },
@@ -977,12 +867,13 @@
         "showMe" : false
       } ],
       "invisible" : false,
-      "name" : "",
+      "name" : "responses",
       "queryItems" : [ {
         "NOT" : false,
-        "iconClass" : "icon-properties",
+        "iconClass" : "sf-icon-property",
         "property" : "plugin",
         "propertyValue" : "kong",
+        "query" : "plugin:\"kong\"",
         "type" : "property",
         "value" : "kong"
       }, {
@@ -1014,28 +905,27 @@
       "seriesData" : { },
       "transient" : true,
       "type" : "plot",
-      "uniqueKey" : 18,
+      "uniqueKey" : 2,
       "yAxisIndex" : 0
     } ],
-    "chartMode" : "graph",
-    "chartType" : "column",
+    "chartMode" : "single",
+    "chartType" : "line",
     "chartconfig" : {
       "absoluteEnd" : null,
       "absoluteStart" : null,
       "colorByMetric" : false,
       "colorByValue" : false,
       "colorByValueScale" : [ ],
+      "hideTimestamp" : false,
       "histogramColor" : "#ea1849",
-      "maxDecimalPlaces" : 4,
+      "maxDecimalPlaces" : 2,
       "range" : -1800000,
       "rangeEnd" : 0,
-      "secondaryVisualization" : "SPARKLINE",
-      "sortPreference" : "+http_method",
-      "stackedChart" : true,
+      "secondaryVisualization" : "NONE",
+      "sortPreference" : "",
       "useKMG2" : false,
       "yAxisConfigurations" : [ {
         "id" : "yAxis0",
-        "label" : "req/intvl",
         "max" : null,
         "min" : null,
         "name" : "yAxis0",
@@ -1045,13 +935,13 @@
         }
       } ]
     },
-    "currentUniqueKey" : 19,
+    "currentUniqueKey" : 3,
     "relatedDetectors" : [ ],
-    "revisionNumber" : 28,
-    "uiHelperValue" : "##CHARTID##_28"
+    "revisionNumber" : 19,
+    "uiHelperValue" : "##CHARTID##_19"
   }
 }, {
-  "marshallId" : 7,
+  "marshallId" : 6,
   "marshallMemberOf" : [ 2 ],
   "sf_chart" : "Upstream Latency",
   "sf_chartIndex" : 1528135368079,
@@ -1360,7 +1250,435 @@
     "uiHelperValue" : "##CHARTID##_34"
   }
 }, {
+  "marshallId" : 7,
+  "marshallMemberOf" : [ 2 ],
+  "sf_chart" : "Requests by HTTP Method",
+  "sf_chartIndex" : 1528138165800,
+  "sf_description" : "Number of Service-fielded requests per interval by HTTP method",
+  "sf_type" : "Chart",
+  "sf_uiModel" : {
+    "allPlots" : [ {
+      "_originalLabel" : "A",
+      "configuration" : {
+        "aliases" : { },
+        "colorOverride" : null,
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
+        "maxExtrapolations" : -1,
+        "rollupPolicy" : "DELTA_ROLLUP",
+        "suffix" : "requests",
+        "unitType" : null
+      },
+      "dataManipulations" : [ {
+        "direction" : {
+          "options" : {
+            "aggregateGroupBy" : [ {
+              "value" : "http_method"
+            } ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          },
+          "type" : "aggregation"
+        },
+        "fn" : {
+          "options" : { },
+          "type" : "SUM"
+        },
+        "showMe" : false
+      } ],
+      "invisible" : false,
+      "name" : "",
+      "queryItems" : [ {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "plugin",
+        "propertyValue" : "kong",
+        "type" : "property",
+        "value" : "kong"
+      }, {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "service_name",
+        "propertyValue" : "*",
+        "type" : "property",
+        "value" : "*"
+      } ],
+      "seriesData" : {
+        "metric" : "counter.kong.responses.count"
+      },
+      "transient" : false,
+      "type" : "plot",
+      "uniqueKey" : 1,
+      "yAxisIndex" : 0
+    }, {
+      "configuration" : {
+        "aliases" : { },
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
+        "maxExtrapolations" : -1
+      },
+      "dataManipulations" : [ ],
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "New Plot",
+      "queryItems" : [ ],
+      "seriesData" : { },
+      "transient" : true,
+      "type" : "plot",
+      "uniqueKey" : 18,
+      "yAxisIndex" : 0
+    } ],
+    "chartMode" : "graph",
+    "chartType" : "column",
+    "chartconfig" : {
+      "absoluteEnd" : null,
+      "absoluteStart" : null,
+      "colorByMetric" : false,
+      "colorByValue" : false,
+      "colorByValueScale" : [ ],
+      "histogramColor" : "#ea1849",
+      "maxDecimalPlaces" : 4,
+      "range" : -1800000,
+      "rangeEnd" : 0,
+      "secondaryVisualization" : "SPARKLINE",
+      "sortPreference" : "+http_method",
+      "stackedChart" : true,
+      "useKMG2" : false,
+      "yAxisConfigurations" : [ {
+        "id" : "yAxis0",
+        "label" : "req/intvl",
+        "max" : null,
+        "min" : null,
+        "name" : "yAxis0",
+        "plotlines" : {
+          "high" : null,
+          "low" : null
+        }
+      } ]
+    },
+    "currentUniqueKey" : 19,
+    "relatedDetectors" : [ ],
+    "revisionNumber" : 28,
+    "uiHelperValue" : "##CHARTID##_28"
+  }
+}, {
   "marshallId" : 8,
+  "marshallMemberOf" : [ 2 ],
+  "sf_chart" : "Kong Latency",
+  "sf_chartIndex" : 1528147046843,
+  "sf_description" : "Average Kong-induced latency for requests compared with -24h average",
+  "sf_type" : "Chart",
+  "sf_uiModel" : {
+    "allPlots" : [ {
+      "_originalLabel" : "J",
+      "configuration" : {
+        "aliases" : { },
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
+        "maxExtrapolations" : -1,
+        "prefix" : "",
+        "rollupPolicy" : "LATEST_ROLLUP",
+        "suffix" : "",
+        "unitType" : "Millisecond"
+      },
+      "dataManipulations" : [ {
+        "direction" : {
+          "options" : {
+            "aggregateGroupBy" : [ {
+              "value" : "service_name"
+            } ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          },
+          "type" : "aggregation"
+        },
+        "fn" : {
+          "options" : { },
+          "type" : "SUM"
+        },
+        "showMe" : false
+      } ],
+      "invisible" : true,
+      "name" : "counter.kong.kong.latency - Sum by service_name",
+      "queryItems" : [ {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "plugin",
+        "propertyValue" : "kong",
+        "type" : "property",
+        "value" : "kong"
+      }, {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "service_name",
+        "propertyValue" : "*",
+        "type" : "property",
+        "value" : "*"
+      } ],
+      "seriesData" : {
+        "metric" : "counter.kong.kong.latency",
+        "regExStyle" : null
+      },
+      "transient" : false,
+      "type" : "plot",
+      "uniqueKey" : 10,
+      "yAxisIndex" : 0
+    }, {
+      "_originalLabel" : "K",
+      "configuration" : {
+        "aliases" : { },
+        "colorOverride" : "#ab99bc",
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
+        "maxExtrapolations" : -1,
+        "rollupPolicy" : "LATEST_ROLLUP"
+      },
+      "dataManipulations" : [ {
+        "direction" : {
+          "options" : {
+            "aggregateGroupBy" : [ {
+              "value" : "service_name"
+            } ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          },
+          "type" : "aggregation"
+        },
+        "fn" : {
+          "options" : { },
+          "type" : "SUM"
+        },
+        "showMe" : false
+      } ],
+      "invisible" : true,
+      "metricDefinition" : { },
+      "name" : "counter.kong.responses.count - Sum by service_name",
+      "queryItems" : [ {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "plugin",
+        "propertyValue" : "kong",
+        "type" : "property",
+        "value" : "kong"
+      }, {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "service_name",
+        "propertyValue" : "*",
+        "type" : "property",
+        "value" : "*"
+      } ],
+      "seriesData" : {
+        "metric" : "counter.kong.responses.count",
+        "regExStyle" : null
+      },
+      "transient" : false,
+      "type" : "plot",
+      "uniqueKey" : 11,
+      "yAxisIndex" : 0
+    }, {
+      "_originalLabel" : "L",
+      "configuration" : {
+        "aliases" : { },
+        "colorOverride" : null,
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
+        "maxExtrapolations" : -1,
+        "prefix" : "",
+        "suffix" : "",
+        "unitType" : "Millisecond"
+      },
+      "dataManipulations" : [ ],
+      "expressionText" : "J / K",
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "latency",
+      "queryItems" : [ ],
+      "seriesData" : {
+        "metric" : null
+      },
+      "transient" : false,
+      "type" : "ratio",
+      "uniqueKey" : 12,
+      "valid" : true,
+      "yAxisIndex" : 0
+    }, {
+      "_originalLabel" : "O",
+      "configuration" : {
+        "aliases" : { },
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
+        "maxExtrapolations" : -1
+      },
+      "dataManipulations" : [ {
+        "direction" : {
+          "options" : {
+            "aggregateGroupBy" : [ ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          },
+          "type" : "aggregation"
+        },
+        "fn" : {
+          "options" : { },
+          "type" : "SUM"
+        },
+        "showMe" : false
+      } ],
+      "expressionText" : "J",
+      "invisible" : true,
+      "metricDefinition" : { },
+      "name" : "J - Sum",
+      "queryItems" : [ ],
+      "seriesData" : {
+        "metric" : null
+      },
+      "transient" : false,
+      "type" : "ratio",
+      "uniqueKey" : 15,
+      "valid" : true,
+      "yAxisIndex" : 0
+    }, {
+      "_originalLabel" : "P",
+      "configuration" : {
+        "aliases" : { },
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
+        "maxExtrapolations" : -1
+      },
+      "dataManipulations" : [ {
+        "direction" : {
+          "options" : {
+            "aggregateGroupBy" : [ ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          },
+          "type" : "aggregation"
+        },
+        "fn" : {
+          "options" : { },
+          "type" : "SUM"
+        },
+        "showMe" : false
+      } ],
+      "expressionText" : "K",
+      "invisible" : true,
+      "metricDefinition" : { },
+      "name" : "K - Sum",
+      "queryItems" : [ ],
+      "seriesData" : {
+        "metric" : null
+      },
+      "transient" : false,
+      "type" : "ratio",
+      "uniqueKey" : 16,
+      "valid" : true,
+      "yAxisIndex" : 0
+    }, {
+      "_originalLabel" : "Q",
+      "configuration" : {
+        "aliases" : { },
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
+        "maxExtrapolations" : -1,
+        "prefix" : "",
+        "suffix" : "",
+        "unitType" : "Millisecond",
+        "visualization" : "line"
+      },
+      "dataManipulations" : [ {
+        "direction" : {
+          "options" : {
+            "aggregateGroupBy" : [ ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          },
+          "type" : "aggregation"
+        },
+        "fn" : {
+          "options" : {
+            "milliseconds" : 86400000
+          },
+          "type" : "TIMESHIFT"
+        },
+        "showMe" : false
+      } ],
+      "expressionText" : "O/P",
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "latency (historic)",
+      "queryItems" : [ ],
+      "seriesData" : {
+        "metric" : null
+      },
+      "transient" : false,
+      "type" : "ratio",
+      "uniqueKey" : 17,
+      "valid" : true,
+      "yAxisIndex" : 1
+    }, {
+      "configuration" : {
+        "aliases" : { },
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
+        "maxExtrapolations" : -1
+      },
+      "dataManipulations" : [ ],
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "New Plot",
+      "queryItems" : [ ],
+      "seriesData" : { },
+      "transient" : true,
+      "type" : "plot",
+      "uniqueKey" : 18,
+      "yAxisIndex" : 0
+    } ],
+    "chartMode" : "graph",
+    "chartType" : "heatmap",
+    "chartconfig" : {
+      "absoluteEnd" : null,
+      "absoluteStart" : null,
+      "colorByMetric" : false,
+      "colorByValue" : false,
+      "colorByValueScale" : [ ],
+      "groupBy" : [ ],
+      "heatmapAutoGradients" : 5,
+      "heatmapColorRange" : { },
+      "heatmapSortBy" : {
+        "asc" : true,
+        "value" : { }
+      },
+      "heatmapUnitsPerRow" : 0,
+      "heatmapUseValueAsColor" : false,
+      "hideTimestamp" : false,
+      "histogramColor" : "#ab99bc",
+      "range" : -1800000,
+      "rangeEnd" : 0,
+      "secondaryVisualization" : "SPARKLINE",
+      "sortPreference" : "-value",
+      "useKMG2" : false,
+      "yAxisConfigurations" : [ {
+        "id" : "yAxis0",
+        "label" : "latency/req",
+        "max" : null,
+        "min" : null,
+        "name" : "yAxis0",
+        "plotlines" : {
+          "high" : null,
+          "low" : null
+        }
+      }, {
+        "label" : "latency/req",
+        "max" : null,
+        "min" : null,
+        "plotlines" : {
+          "high" : null,
+          "low" : null
+        },
+        "title" : {
+          "text" : ""
+        }
+      } ]
+    },
+    "currentUniqueKey" : 19,
+    "relatedDetectors" : [ ],
+    "revisionNumber" : 28,
+    "uiHelperValue" : "##CHARTID##_28"
+  }
+}, {
+  "marshallId" : 9,
   "marshallMemberOf" : [ 2 ],
   "sf_chart" : "Response Size",
   "sf_chartIndex" : 1528139299895,
@@ -1685,455 +2003,7 @@
     "uiHelperValue" : "##CHARTID##_39"
   }
 }, {
-  "marshallId" : 9,
-  "marshallMemberOf" : [ 2 ],
-  "sf_chart" : "Kong Latency",
-  "sf_chartIndex" : 1528147046843,
-  "sf_description" : "Average Kong-induced latency for requests compared with -24h average",
-  "sf_type" : "Chart",
-  "sf_uiModel" : {
-    "allPlots" : [ {
-      "_originalLabel" : "J",
-      "configuration" : {
-        "aliases" : { },
-        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
-        "maxExtrapolations" : -1,
-        "prefix" : "",
-        "rollupPolicy" : "LATEST_ROLLUP",
-        "suffix" : "",
-        "unitType" : "Millisecond"
-      },
-      "dataManipulations" : [ {
-        "direction" : {
-          "options" : {
-            "aggregateGroupBy" : [ {
-              "value" : "service_name"
-            } ],
-            "collapseGroups" : false,
-            "transformTimeRange" : null
-          },
-          "type" : "aggregation"
-        },
-        "fn" : {
-          "options" : { },
-          "type" : "SUM"
-        },
-        "showMe" : false
-      } ],
-      "invisible" : true,
-      "name" : "counter.kong.kong.latency - Sum by service_name",
-      "queryItems" : [ {
-        "NOT" : false,
-        "iconClass" : "icon-properties",
-        "property" : "plugin",
-        "propertyValue" : "kong",
-        "type" : "property",
-        "value" : "kong"
-      }, {
-        "NOT" : false,
-        "iconClass" : "icon-properties",
-        "property" : "service_name",
-        "propertyValue" : "*",
-        "type" : "property",
-        "value" : "*"
-      } ],
-      "seriesData" : {
-        "metric" : "counter.kong.kong.latency",
-        "regExStyle" : null
-      },
-      "transient" : false,
-      "type" : "plot",
-      "uniqueKey" : 10,
-      "yAxisIndex" : 0
-    }, {
-      "_originalLabel" : "K",
-      "configuration" : {
-        "aliases" : { },
-        "colorOverride" : "#ab99bc",
-        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
-        "maxExtrapolations" : -1,
-        "rollupPolicy" : "LATEST_ROLLUP"
-      },
-      "dataManipulations" : [ {
-        "direction" : {
-          "options" : {
-            "aggregateGroupBy" : [ {
-              "value" : "service_name"
-            } ],
-            "collapseGroups" : false,
-            "transformTimeRange" : null
-          },
-          "type" : "aggregation"
-        },
-        "fn" : {
-          "options" : { },
-          "type" : "SUM"
-        },
-        "showMe" : false
-      } ],
-      "invisible" : true,
-      "metricDefinition" : { },
-      "name" : "counter.kong.responses.count - Sum by service_name",
-      "queryItems" : [ {
-        "NOT" : false,
-        "iconClass" : "icon-properties",
-        "property" : "plugin",
-        "propertyValue" : "kong",
-        "type" : "property",
-        "value" : "kong"
-      }, {
-        "NOT" : false,
-        "iconClass" : "icon-properties",
-        "property" : "service_name",
-        "propertyValue" : "*",
-        "type" : "property",
-        "value" : "*"
-      } ],
-      "seriesData" : {
-        "metric" : "counter.kong.responses.count",
-        "regExStyle" : null
-      },
-      "transient" : false,
-      "type" : "plot",
-      "uniqueKey" : 11,
-      "yAxisIndex" : 0
-    }, {
-      "_originalLabel" : "L",
-      "configuration" : {
-        "aliases" : { },
-        "colorOverride" : null,
-        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
-        "maxExtrapolations" : -1,
-        "prefix" : "",
-        "suffix" : "",
-        "unitType" : "Millisecond"
-      },
-      "dataManipulations" : [ ],
-      "expressionText" : "J / K",
-      "invisible" : false,
-      "metricDefinition" : { },
-      "name" : "latency",
-      "queryItems" : [ ],
-      "seriesData" : {
-        "metric" : null
-      },
-      "transient" : false,
-      "type" : "ratio",
-      "uniqueKey" : 12,
-      "valid" : true,
-      "yAxisIndex" : 0
-    }, {
-      "_originalLabel" : "O",
-      "configuration" : {
-        "aliases" : { },
-        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
-        "maxExtrapolations" : -1
-      },
-      "dataManipulations" : [ {
-        "direction" : {
-          "options" : {
-            "aggregateGroupBy" : [ ],
-            "collapseGroups" : false,
-            "transformTimeRange" : null
-          },
-          "type" : "aggregation"
-        },
-        "fn" : {
-          "options" : { },
-          "type" : "SUM"
-        },
-        "showMe" : false
-      } ],
-      "expressionText" : "J",
-      "invisible" : true,
-      "metricDefinition" : { },
-      "name" : "J - Sum",
-      "queryItems" : [ ],
-      "seriesData" : {
-        "metric" : null
-      },
-      "transient" : false,
-      "type" : "ratio",
-      "uniqueKey" : 15,
-      "valid" : true,
-      "yAxisIndex" : 0
-    }, {
-      "_originalLabel" : "P",
-      "configuration" : {
-        "aliases" : { },
-        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
-        "maxExtrapolations" : -1
-      },
-      "dataManipulations" : [ {
-        "direction" : {
-          "options" : {
-            "aggregateGroupBy" : [ ],
-            "collapseGroups" : false,
-            "transformTimeRange" : null
-          },
-          "type" : "aggregation"
-        },
-        "fn" : {
-          "options" : { },
-          "type" : "SUM"
-        },
-        "showMe" : false
-      } ],
-      "expressionText" : "K",
-      "invisible" : true,
-      "metricDefinition" : { },
-      "name" : "K - Sum",
-      "queryItems" : [ ],
-      "seriesData" : {
-        "metric" : null
-      },
-      "transient" : false,
-      "type" : "ratio",
-      "uniqueKey" : 16,
-      "valid" : true,
-      "yAxisIndex" : 0
-    }, {
-      "_originalLabel" : "Q",
-      "configuration" : {
-        "aliases" : { },
-        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
-        "maxExtrapolations" : -1,
-        "prefix" : "",
-        "suffix" : "",
-        "unitType" : "Millisecond",
-        "visualization" : "line"
-      },
-      "dataManipulations" : [ {
-        "direction" : {
-          "options" : {
-            "aggregateGroupBy" : [ ],
-            "collapseGroups" : false,
-            "transformTimeRange" : null
-          },
-          "type" : "aggregation"
-        },
-        "fn" : {
-          "options" : {
-            "milliseconds" : 86400000
-          },
-          "type" : "TIMESHIFT"
-        },
-        "showMe" : false
-      } ],
-      "expressionText" : "O/P",
-      "invisible" : false,
-      "metricDefinition" : { },
-      "name" : "latency (historic)",
-      "queryItems" : [ ],
-      "seriesData" : {
-        "metric" : null
-      },
-      "transient" : false,
-      "type" : "ratio",
-      "uniqueKey" : 17,
-      "valid" : true,
-      "yAxisIndex" : 1
-    }, {
-      "configuration" : {
-        "aliases" : { },
-        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
-        "maxExtrapolations" : -1
-      },
-      "dataManipulations" : [ ],
-      "invisible" : false,
-      "metricDefinition" : { },
-      "name" : "New Plot",
-      "queryItems" : [ ],
-      "seriesData" : { },
-      "transient" : true,
-      "type" : "plot",
-      "uniqueKey" : 18,
-      "yAxisIndex" : 0
-    } ],
-    "chartMode" : "graph",
-    "chartType" : "heatmap",
-    "chartconfig" : {
-      "absoluteEnd" : null,
-      "absoluteStart" : null,
-      "colorByMetric" : false,
-      "colorByValue" : false,
-      "colorByValueScale" : [ ],
-      "groupBy" : [ ],
-      "heatmapAutoGradients" : 5,
-      "heatmapColorRange" : { },
-      "heatmapSortBy" : {
-        "asc" : true,
-        "value" : { }
-      },
-      "heatmapUnitsPerRow" : 0,
-      "heatmapUseValueAsColor" : false,
-      "hideTimestamp" : false,
-      "histogramColor" : "#ab99bc",
-      "range" : -1800000,
-      "rangeEnd" : 0,
-      "secondaryVisualization" : "SPARKLINE",
-      "sortPreference" : "-value",
-      "useKMG2" : false,
-      "yAxisConfigurations" : [ {
-        "id" : "yAxis0",
-        "label" : "latency/req",
-        "max" : null,
-        "min" : null,
-        "name" : "yAxis0",
-        "plotlines" : {
-          "high" : null,
-          "low" : null
-        }
-      }, {
-        "label" : "latency/req",
-        "max" : null,
-        "min" : null,
-        "plotlines" : {
-          "high" : null,
-          "low" : null
-        },
-        "title" : {
-          "text" : ""
-        }
-      } ]
-    },
-    "currentUniqueKey" : 19,
-    "relatedDetectors" : [ ],
-    "revisionNumber" : 28,
-    "uiHelperValue" : "##CHARTID##_28"
-  }
-}, {
   "marshallId" : 10,
-  "marshallMemberOf" : [ 2 ],
-  "sf_chart" : "4xx Responses by HTTP Method",
-  "sf_chartIndex" : 1528312603879,
-  "sf_description" : "Number of 4xx errors per interval by HTTP method",
-  "sf_type" : "Chart",
-  "sf_uiModel" : {
-    "allPlots" : [ {
-      "_originalLabel" : "A",
-      "configuration" : {
-        "aliases" : { },
-        "colorOverride" : null,
-        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
-        "maxExtrapolations" : -1,
-        "rollupPolicy" : "DELTA_ROLLUP",
-        "suffix" : "errors",
-        "unitType" : null
-      },
-      "dataManipulations" : [ {
-        "direction" : {
-          "options" : {
-            "aggregateGroupBy" : [ {
-              "value" : "http_method"
-            }, {
-              "value" : "status_code"
-            } ],
-            "collapseGroups" : false,
-            "transformTimeRange" : null
-          },
-          "type" : "aggregation"
-        },
-        "fn" : {
-          "options" : { },
-          "type" : "SUM"
-        },
-        "showMe" : false
-      } ],
-      "invisible" : false,
-      "name" : "errors",
-      "queryItems" : [ {
-        "NOT" : false,
-        "iconClass" : "icon-properties",
-        "property" : "plugin",
-        "propertyValue" : "kong",
-        "type" : "property",
-        "value" : "kong"
-      }, {
-        "NOT" : false,
-        "iconClass" : "icon-properties",
-        "property" : "status_code",
-        "propertyValue" : "4*",
-        "type" : "property",
-        "value" : "201"
-      }, {
-        "NOT" : false,
-        "iconClass" : "icon-properties",
-        "property" : "service_name",
-        "propertyValue" : "*",
-        "type" : "property",
-        "value" : "*"
-      } ],
-      "seriesData" : {
-        "metric" : "counter.kong.responses.count",
-        "regExStyle" : null
-      },
-      "transient" : false,
-      "type" : "plot",
-      "uniqueKey" : 1,
-      "yAxisIndex" : 0
-    }, {
-      "configuration" : {
-        "aliases" : { },
-        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
-        "maxExtrapolations" : -1
-      },
-      "dataManipulations" : [ ],
-      "invisible" : false,
-      "metricDefinition" : { },
-      "name" : "New Plot",
-      "queryItems" : [ ],
-      "seriesData" : { },
-      "transient" : true,
-      "type" : "plot",
-      "uniqueKey" : 18,
-      "yAxisIndex" : 0
-    } ],
-    "chartMode" : "graph",
-    "chartType" : "column",
-    "chartconfig" : {
-      "absoluteEnd" : null,
-      "absoluteStart" : null,
-      "colorByMetric" : false,
-      "colorByValue" : false,
-      "colorByValueScale" : [ ],
-      "groupBy" : [ ],
-      "heatmapAutoGradients" : 5,
-      "heatmapColorRange" : { },
-      "heatmapSortBy" : {
-        "asc" : true,
-        "value" : { }
-      },
-      "heatmapUnitsPerRow" : 0,
-      "heatmapUseValueAsColor" : false,
-      "hideTimestamp" : false,
-      "histogramColor" : "#ea1849",
-      "maxDecimalPlaces" : 4,
-      "range" : -1800000,
-      "rangeEnd" : 0,
-      "secondaryVisualization" : "SPARKLINE",
-      "sortPreference" : "",
-      "stackedChart" : true,
-      "useKMG2" : false,
-      "yAxisConfigurations" : [ {
-        "id" : "yAxis0",
-        "label" : "errors/intvl",
-        "max" : null,
-        "min" : null,
-        "name" : "yAxis0",
-        "plotlines" : {
-          "high" : null,
-          "low" : null
-        }
-      } ]
-    },
-    "currentUniqueKey" : 19,
-    "relatedDetectors" : [ ],
-    "revisionNumber" : 30,
-    "uiHelperValue" : "##CHARTID##_30"
-  }
-}, {
-  "marshallId" : 11,
   "marshallMemberOf" : [ 2 ],
   "sf_chart" : "Responses",
   "sf_chartIndex" : 1528304230699,
@@ -2268,11 +2138,30 @@
         "extrapolationPolicy" : "NULL_EXTRAPOLATION",
         "maxExtrapolations" : -1
       },
-      "dataManipulations" : [ ],
+      "dataManipulations" : [ {
+        "direction" : {
+          "options" : {
+            "aggregateGroupBy" : [ ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          },
+          "type" : "aggregation"
+        },
+        "fn" : {
+          "options" : {
+            "action" : "drop",
+            "inclusive" : true,
+            "low" : 0,
+            "mode" : "below"
+          },
+          "type" : "EXCLUDE"
+        },
+        "showMe" : false
+      } ],
       "expressionText" : "A-B",
       "invisible" : false,
       "metricDefinition" : { },
-      "name" : "A-B",
+      "name" : "A-B - Exclude x <= 0",
       "queryItems" : [ ],
       "seriesData" : {
         "metric" : null
@@ -2328,11 +2217,271 @@
     },
     "currentUniqueKey" : 5,
     "relatedDetectors" : [ ],
-    "revisionNumber" : 23,
-    "uiHelperValue" : "##CHARTID##_23"
+    "revisionNumber" : 25,
+    "uiHelperValue" : "##CHARTID##_25"
+  }
+}, {
+  "marshallId" : 11,
+  "marshallMemberOf" : [ 2 ],
+  "sf_chart" : "4xx Responses by HTTP Method",
+  "sf_chartIndex" : 1528312603879,
+  "sf_description" : "Number of 4xx errors per interval by HTTP method",
+  "sf_type" : "Chart",
+  "sf_uiModel" : {
+    "allPlots" : [ {
+      "_originalLabel" : "A",
+      "configuration" : {
+        "aliases" : { },
+        "colorOverride" : null,
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
+        "maxExtrapolations" : -1,
+        "rollupPolicy" : "DELTA_ROLLUP",
+        "suffix" : "errors",
+        "unitType" : null
+      },
+      "dataManipulations" : [ {
+        "direction" : {
+          "options" : {
+            "aggregateGroupBy" : [ {
+              "value" : "http_method"
+            }, {
+              "value" : "status_code"
+            } ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          },
+          "type" : "aggregation"
+        },
+        "fn" : {
+          "options" : { },
+          "type" : "SUM"
+        },
+        "showMe" : false
+      } ],
+      "invisible" : false,
+      "name" : "errors",
+      "queryItems" : [ {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "plugin",
+        "propertyValue" : "kong",
+        "type" : "property",
+        "value" : "kong"
+      }, {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "status_code",
+        "propertyValue" : "4*",
+        "type" : "property",
+        "value" : "201"
+      }, {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "service_name",
+        "propertyValue" : "*",
+        "type" : "property",
+        "value" : "*"
+      } ],
+      "seriesData" : {
+        "metric" : "counter.kong.responses.count",
+        "regExStyle" : null
+      },
+      "transient" : false,
+      "type" : "plot",
+      "uniqueKey" : 1,
+      "yAxisIndex" : 0
+    }, {
+      "configuration" : {
+        "aliases" : { },
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
+        "maxExtrapolations" : -1
+      },
+      "dataManipulations" : [ ],
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "New Plot",
+      "queryItems" : [ ],
+      "seriesData" : { },
+      "transient" : true,
+      "type" : "plot",
+      "uniqueKey" : 18,
+      "yAxisIndex" : 0
+    } ],
+    "chartMode" : "graph",
+    "chartType" : "column",
+    "chartconfig" : {
+      "absoluteEnd" : null,
+      "absoluteStart" : null,
+      "colorByMetric" : false,
+      "colorByValue" : false,
+      "colorByValueScale" : [ ],
+      "groupBy" : [ ],
+      "heatmapAutoGradients" : 5,
+      "heatmapColorRange" : { },
+      "heatmapSortBy" : {
+        "asc" : true,
+        "value" : { }
+      },
+      "heatmapUnitsPerRow" : 0,
+      "heatmapUseValueAsColor" : false,
+      "hideTimestamp" : false,
+      "histogramColor" : "#ea1849",
+      "maxDecimalPlaces" : 4,
+      "range" : -1800000,
+      "rangeEnd" : 0,
+      "secondaryVisualization" : "SPARKLINE",
+      "sortPreference" : "",
+      "stackedChart" : true,
+      "useKMG2" : false,
+      "yAxisConfigurations" : [ {
+        "id" : "yAxis0",
+        "label" : "errors/intvl",
+        "max" : null,
+        "min" : null,
+        "name" : "yAxis0",
+        "plotlines" : {
+          "high" : null,
+          "low" : null
+        }
+      } ]
+    },
+    "currentUniqueKey" : 19,
+    "relatedDetectors" : [ ],
+    "revisionNumber" : 30,
+    "uiHelperValue" : "##CHARTID##_30"
   }
 }, {
   "marshallId" : 12,
+  "marshallMemberOf" : [ 2 ],
+  "sf_chart" : "5xx Responses by HTTP Method",
+  "sf_chartIndex" : 1528313719962,
+  "sf_description" : "Number of 5xx errors per interval by HTTP method",
+  "sf_type" : "Chart",
+  "sf_uiModel" : {
+    "allPlots" : [ {
+      "_originalLabel" : "A",
+      "configuration" : {
+        "aliases" : { },
+        "colorOverride" : null,
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
+        "maxExtrapolations" : -1,
+        "rollupPolicy" : "DELTA_ROLLUP",
+        "suffix" : "errors",
+        "unitType" : null
+      },
+      "dataManipulations" : [ {
+        "direction" : {
+          "options" : {
+            "aggregateGroupBy" : [ {
+              "value" : "http_method"
+            }, {
+              "value" : "status_code"
+            } ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          },
+          "type" : "aggregation"
+        },
+        "fn" : {
+          "options" : { },
+          "type" : "SUM"
+        },
+        "showMe" : false
+      } ],
+      "invisible" : false,
+      "name" : "errors",
+      "queryItems" : [ {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "plugin",
+        "propertyValue" : "kong",
+        "type" : "property",
+        "value" : "kong"
+      }, {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "status_code",
+        "propertyValue" : "5*",
+        "type" : "property",
+        "value" : "201"
+      }, {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "service_name",
+        "propertyValue" : "*",
+        "type" : "property",
+        "value" : "*"
+      } ],
+      "seriesData" : {
+        "metric" : "counter.kong.responses.count",
+        "regExStyle" : null
+      },
+      "transient" : false,
+      "type" : "plot",
+      "uniqueKey" : 1,
+      "yAxisIndex" : 0
+    }, {
+      "configuration" : {
+        "aliases" : { },
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
+        "maxExtrapolations" : -1
+      },
+      "dataManipulations" : [ ],
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "New Plot",
+      "queryItems" : [ ],
+      "seriesData" : { },
+      "transient" : true,
+      "type" : "plot",
+      "uniqueKey" : 18,
+      "yAxisIndex" : 0
+    } ],
+    "chartMode" : "graph",
+    "chartType" : "column",
+    "chartconfig" : {
+      "absoluteEnd" : null,
+      "absoluteStart" : null,
+      "colorByMetric" : false,
+      "colorByValue" : false,
+      "colorByValueScale" : [ ],
+      "groupBy" : [ ],
+      "heatmapAutoGradients" : 5,
+      "heatmapColorRange" : { },
+      "heatmapSortBy" : {
+        "asc" : true,
+        "value" : { }
+      },
+      "heatmapUnitsPerRow" : 0,
+      "heatmapUseValueAsColor" : false,
+      "hideTimestamp" : false,
+      "histogramColor" : "#ea1849",
+      "maxDecimalPlaces" : 4,
+      "range" : -1800000,
+      "rangeEnd" : 0,
+      "secondaryVisualization" : "SPARKLINE",
+      "sortPreference" : "",
+      "stackedChart" : true,
+      "useKMG2" : false,
+      "yAxisConfigurations" : [ {
+        "id" : "yAxis0",
+        "label" : "errors/intvl",
+        "max" : null,
+        "min" : null,
+        "name" : "yAxis0",
+        "plotlines" : {
+          "high" : null,
+          "low" : null
+        }
+      } ]
+    },
+    "currentUniqueKey" : 19,
+    "relatedDetectors" : [ ],
+    "revisionNumber" : 28,
+    "uiHelperValue" : "##CHARTID##_28"
+  }
+}, {
+  "marshallId" : 13,
   "marshallMemberOf" : [ 2 ],
   "sf_chart" : "Responses / Second",
   "sf_chartIndex" : 1528219376990,
@@ -2512,159 +2661,18 @@
     "uiHelperValue" : "##CHARTID##_37"
   }
 }, {
-  "marshallId" : 13,
-  "marshallMemberOf" : [ 2 ],
-  "sf_chart" : "5xx Responses by HTTP Method",
-  "sf_chartIndex" : 1528313719962,
-  "sf_description" : "Number of 5xx errors per interval by HTTP method",
-  "sf_type" : "Chart",
-  "sf_uiModel" : {
-    "allPlots" : [ {
-      "_originalLabel" : "A",
-      "configuration" : {
-        "aliases" : { },
-        "colorOverride" : null,
-        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
-        "maxExtrapolations" : -1,
-        "rollupPolicy" : "DELTA_ROLLUP",
-        "suffix" : "errors",
-        "unitType" : null
-      },
-      "dataManipulations" : [ {
-        "direction" : {
-          "options" : {
-            "aggregateGroupBy" : [ {
-              "value" : "http_method"
-            }, {
-              "value" : "status_code"
-            } ],
-            "collapseGroups" : false,
-            "transformTimeRange" : null
-          },
-          "type" : "aggregation"
-        },
-        "fn" : {
-          "options" : { },
-          "type" : "SUM"
-        },
-        "showMe" : false
-      } ],
-      "invisible" : false,
-      "name" : "errors",
-      "queryItems" : [ {
-        "NOT" : false,
-        "iconClass" : "icon-properties",
-        "property" : "plugin",
-        "propertyValue" : "kong",
-        "type" : "property",
-        "value" : "kong"
-      }, {
-        "NOT" : false,
-        "iconClass" : "icon-properties",
-        "property" : "status_code",
-        "propertyValue" : "5*",
-        "type" : "property",
-        "value" : "201"
-      }, {
-        "NOT" : false,
-        "iconClass" : "icon-properties",
-        "property" : "service_name",
-        "propertyValue" : "*",
-        "type" : "property",
-        "value" : "*"
-      } ],
-      "seriesData" : {
-        "metric" : "counter.kong.responses.count",
-        "regExStyle" : null
-      },
-      "transient" : false,
-      "type" : "plot",
-      "uniqueKey" : 1,
-      "yAxisIndex" : 0
-    }, {
-      "configuration" : {
-        "aliases" : { },
-        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
-        "maxExtrapolations" : -1
-      },
-      "dataManipulations" : [ ],
-      "invisible" : false,
-      "metricDefinition" : { },
-      "name" : "New Plot",
-      "queryItems" : [ ],
-      "seriesData" : { },
-      "transient" : true,
-      "type" : "plot",
-      "uniqueKey" : 18,
-      "yAxisIndex" : 0
-    } ],
-    "chartMode" : "graph",
-    "chartType" : "column",
-    "chartconfig" : {
-      "absoluteEnd" : null,
-      "absoluteStart" : null,
-      "colorByMetric" : false,
-      "colorByValue" : false,
-      "colorByValueScale" : [ ],
-      "groupBy" : [ ],
-      "heatmapAutoGradients" : 5,
-      "heatmapColorRange" : { },
-      "heatmapSortBy" : {
-        "asc" : true,
-        "value" : { }
-      },
-      "heatmapUnitsPerRow" : 0,
-      "heatmapUseValueAsColor" : false,
-      "hideTimestamp" : false,
-      "histogramColor" : "#ea1849",
-      "maxDecimalPlaces" : 4,
-      "range" : -1800000,
-      "rangeEnd" : 0,
-      "secondaryVisualization" : "SPARKLINE",
-      "sortPreference" : "",
-      "stackedChart" : true,
-      "useKMG2" : false,
-      "yAxisConfigurations" : [ {
-        "id" : "yAxis0",
-        "label" : "errors/intvl",
-        "max" : null,
-        "min" : null,
-        "name" : "yAxis0",
-        "plotlines" : {
-          "high" : null,
-          "low" : null
-        }
-      } ]
-    },
-    "currentUniqueKey" : 19,
-    "relatedDetectors" : [ ],
-    "revisionNumber" : 28,
-    "uiHelperValue" : "##CHARTID##_28"
-  }
-}, {
   "marshallId" : 14,
   "marshallMemberOf" : [ 1 ],
-  "sf_dashboard" : "API Objects",
-  "sf_description" : "API object activity metrics",
-  "sf_discoveryQuery" : "plugin:kong AND (__exists__:api_id OR __exists__:api_name)",
-  "sf_discoverySelectors" : [ "plugin:kong", "__exists__:api_name" ],
+  "sf_dashboard" : "Route Objects",
+  "sf_description" : "Route object activity metrics",
+  "sf_discoveryQuery" : "plugin:kong AND __exists__:route_id",
+  "sf_discoverySelectors" : [ "plugin:kong", "__exists__:route_id" ],
   "sf_filterAlias" : {
     "variables" : [ {
-      "alias" : "API Name",
+      "alias" : "Route ID",
       "applyIfExists" : false,
       "description" : "",
-      "dimension" : "api_name",
-      "globalScope" : false,
-      "preferredSuggestions" : [ ],
-      "replaceOnly" : false,
-      "required" : false,
-      "restricted" : false,
-      "value" : ""
-    }, {
-      "alias" : "API ID",
-      "applyIfExists" : false,
-      "description" : "",
-      "dimension" : "api_id",
+      "dimension" : "route_id",
       "globalScope" : false,
       "preferredSuggestions" : [ ],
       "replaceOnly" : false,
@@ -2683,20 +2691,20 @@
       "relative" : true,
       "start" : "-1h"
     },
-    "variables" : [ "API Name=api_name:", "API ID=api_id:" ]
+    "variables" : [ "Route ID=route_id:" ]
   },
   "sf_selectedEventOverlays" : [ ],
   "sf_type" : "Dashboard",
   "sf_uiModel" : {
     "version" : 1,
     "widgets" : [ {
-      "col" : 6,
+      "col" : 0,
       "options" : {
-        "chartIndex" : 1528219376990,
+        "chartIndex" : 1528304230699,
         "id" : 0
       },
       "row" : 0,
-      "sizeX" : 6,
+      "sizeX" : 3,
       "sizeY" : 1
     }, {
       "col" : 3,
@@ -2708,13 +2716,13 @@
       "sizeX" : 3,
       "sizeY" : 1
     }, {
-      "col" : 0,
+      "col" : 6,
       "options" : {
-        "chartIndex" : 1528304230699,
+        "chartIndex" : 1528219376990,
         "id" : 0
       },
       "row" : 0,
-      "sizeX" : 3,
+      "sizeX" : 6,
       "sizeY" : 1
     }, {
       "col" : 6,
@@ -2793,6 +2801,354 @@
 }, {
   "marshallId" : 15,
   "marshallMemberOf" : [ 14 ],
+  "sf_chart" : "Responses",
+  "sf_chartIndex" : 1528304230699,
+  "sf_description" : "Within past hour",
+  "sf_type" : "Chart",
+  "sf_uiModel" : {
+    "allPlots" : [ {
+      "_originalLabel" : "A",
+      "configuration" : {
+        "aliases" : { },
+        "colorOverride" : null,
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
+        "maxExtrapolations" : -1,
+        "prefix" : "",
+        "rollupPolicy" : "SUM_ROLLUP",
+        "suffix" : "",
+        "unitType" : null
+      },
+      "dataManipulations" : [ {
+        "direction" : {
+          "options" : {
+            "aggregateGroupBy" : [ ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          },
+          "type" : "aggregation"
+        },
+        "fn" : {
+          "options" : { },
+          "type" : "SUM"
+        },
+        "showMe" : false
+      } ],
+      "invisible" : true,
+      "name" : "counter.kong.responses.count - Sum",
+      "queryItems" : [ {
+        "NOT" : false,
+        "iconClass" : "sf-icon-property",
+        "property" : "plugin",
+        "propertyValue" : "kong",
+        "query" : "plugin:\"kong\"",
+        "type" : "property",
+        "value" : "kong"
+      }, {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "route_id",
+        "propertyValue" : "*",
+        "type" : "property",
+        "value" : "*"
+      } ],
+      "seriesData" : {
+        "metric" : "counter.kong.responses.count"
+      },
+      "transient" : false,
+      "type" : "plot",
+      "uniqueKey" : 1,
+      "yAxisIndex" : 0
+    }, {
+      "_originalLabel" : "B",
+      "configuration" : {
+        "aliases" : { },
+        "colorOverride" : null,
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
+        "maxExtrapolations" : -1,
+        "prefix" : "",
+        "rollupPolicy" : "SUM_ROLLUP",
+        "suffix" : "",
+        "unitType" : null
+      },
+      "dataManipulations" : [ {
+        "direction" : {
+          "options" : {
+            "aggregateGroupBy" : [ ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          },
+          "type" : "aggregation"
+        },
+        "fn" : {
+          "options" : {
+            "milliseconds" : 3600000
+          },
+          "type" : "TIMESHIFT"
+        },
+        "showMe" : false
+      }, {
+        "direction" : {
+          "options" : {
+            "aggregateGroupBy" : [ ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          },
+          "type" : "aggregation"
+        },
+        "fn" : {
+          "options" : { },
+          "type" : "SUM"
+        },
+        "showMe" : false
+      } ],
+      "invisible" : true,
+      "name" : "counter.kong.responses.count - Timeshift 1h - Sum",
+      "queryItems" : [ {
+        "NOT" : false,
+        "iconClass" : "sf-icon-property",
+        "property" : "plugin",
+        "propertyValue" : "kong",
+        "query" : "plugin:\"kong\"",
+        "type" : "property",
+        "value" : "kong"
+      }, {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "route_id",
+        "propertyValue" : "*",
+        "type" : "property",
+        "value" : "*"
+      } ],
+      "seriesData" : {
+        "metric" : "counter.kong.responses.count"
+      },
+      "transient" : false,
+      "type" : "plot",
+      "uniqueKey" : 2,
+      "yAxisIndex" : 0
+    }, {
+      "_originalLabel" : "C",
+      "configuration" : {
+        "aliases" : { },
+        "colorOverride" : "#00b9ff",
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
+        "maxExtrapolations" : -1
+      },
+      "dataManipulations" : [ {
+        "direction" : {
+          "options" : {
+            "aggregateGroupBy" : [ ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          },
+          "type" : "aggregation"
+        },
+        "fn" : {
+          "options" : {
+            "action" : "drop",
+            "inclusive" : true,
+            "low" : 0,
+            "mode" : "below"
+          },
+          "type" : "EXCLUDE"
+        },
+        "showMe" : false
+      } ],
+      "expressionText" : "A-B",
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "A-B - Exclude x <= 0",
+      "queryItems" : [ ],
+      "seriesData" : {
+        "metric" : null
+      },
+      "transient" : false,
+      "type" : "ratio",
+      "uniqueKey" : 3,
+      "valid" : true,
+      "yAxisIndex" : 0
+    }, {
+      "configuration" : {
+        "aliases" : { },
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
+        "maxExtrapolations" : -1
+      },
+      "dataManipulations" : [ ],
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "New Plot",
+      "queryItems" : [ ],
+      "seriesData" : { },
+      "transient" : true,
+      "type" : "plot",
+      "uniqueKey" : 4,
+      "yAxisIndex" : 0
+    } ],
+    "chartMode" : "single",
+    "chartType" : "line",
+    "chartconfig" : {
+      "absoluteEnd" : null,
+      "absoluteStart" : null,
+      "colorByMetric" : false,
+      "colorByValue" : false,
+      "colorByValueScale" : [ ],
+      "hideTimestamp" : false,
+      "histogramColor" : "#ea1849",
+      "maxDecimalPlaces" : 2,
+      "range" : -1800000,
+      "rangeEnd" : 0,
+      "secondaryVisualization" : "NONE",
+      "sortPreference" : "",
+      "useKMG2" : false,
+      "yAxisConfigurations" : [ {
+        "id" : "yAxis0",
+        "max" : null,
+        "min" : null,
+        "name" : "yAxis0",
+        "plotlines" : {
+          "high" : null,
+          "low" : null
+        }
+      } ]
+    },
+    "currentUniqueKey" : 5,
+    "relatedDetectors" : [ ],
+    "revisionNumber" : 26,
+    "uiHelperValue" : "##CHARTID##_26"
+  }
+}, {
+  "marshallId" : 16,
+  "marshallMemberOf" : [ 14 ],
+  "sf_chart" : "4xx Responses by HTTP Method",
+  "sf_chartIndex" : 1528312603879,
+  "sf_description" : "Number of 4xx errors per interval by HTTP method",
+  "sf_type" : "Chart",
+  "sf_uiModel" : {
+    "allPlots" : [ {
+      "_originalLabel" : "A",
+      "configuration" : {
+        "aliases" : { },
+        "colorOverride" : null,
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
+        "maxExtrapolations" : -1,
+        "rollupPolicy" : "DELTA_ROLLUP",
+        "suffix" : "errors",
+        "unitType" : null
+      },
+      "dataManipulations" : [ {
+        "direction" : {
+          "options" : {
+            "aggregateGroupBy" : [ {
+              "value" : "http_method"
+            }, {
+              "value" : "status_code"
+            } ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          },
+          "type" : "aggregation"
+        },
+        "fn" : {
+          "options" : { },
+          "type" : "SUM"
+        },
+        "showMe" : false
+      } ],
+      "invisible" : false,
+      "name" : "errors",
+      "queryItems" : [ {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "plugin",
+        "propertyValue" : "kong",
+        "type" : "property",
+        "value" : "kong"
+      }, {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "status_code",
+        "propertyValue" : "4*",
+        "type" : "property",
+        "value" : "201"
+      }, {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "route_id",
+        "propertyValue" : "*",
+        "type" : "property",
+        "value" : "*"
+      } ],
+      "seriesData" : {
+        "metric" : "counter.kong.responses.count",
+        "regExStyle" : null
+      },
+      "transient" : false,
+      "type" : "plot",
+      "uniqueKey" : 1,
+      "yAxisIndex" : 0
+    }, {
+      "configuration" : {
+        "aliases" : { },
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
+        "maxExtrapolations" : -1
+      },
+      "dataManipulations" : [ ],
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "New Plot",
+      "queryItems" : [ ],
+      "seriesData" : { },
+      "transient" : true,
+      "type" : "plot",
+      "uniqueKey" : 18,
+      "yAxisIndex" : 0
+    } ],
+    "chartMode" : "graph",
+    "chartType" : "column",
+    "chartconfig" : {
+      "absoluteEnd" : null,
+      "absoluteStart" : null,
+      "colorByMetric" : false,
+      "colorByValue" : false,
+      "colorByValueScale" : [ ],
+      "groupBy" : [ ],
+      "heatmapAutoGradients" : 5,
+      "heatmapColorRange" : { },
+      "heatmapSortBy" : {
+        "asc" : true,
+        "value" : { }
+      },
+      "heatmapUnitsPerRow" : 0,
+      "heatmapUseValueAsColor" : false,
+      "hideTimestamp" : false,
+      "histogramColor" : "#ea1849",
+      "maxDecimalPlaces" : 4,
+      "range" : -1800000,
+      "rangeEnd" : 0,
+      "secondaryVisualization" : "SPARKLINE",
+      "sortPreference" : "",
+      "stackedChart" : true,
+      "useKMG2" : false,
+      "yAxisConfigurations" : [ {
+        "id" : "yAxis0",
+        "label" : "errors/intvl",
+        "max" : null,
+        "min" : null,
+        "name" : "yAxis0",
+        "plotlines" : {
+          "high" : null,
+          "low" : null
+        }
+      } ]
+    },
+    "currentUniqueKey" : 19,
+    "relatedDetectors" : [ ],
+    "revisionNumber" : 32,
+    "uiHelperValue" : "##CHARTID##_32"
+  }
+}, {
+  "marshallId" : 17,
+  "marshallMemberOf" : [ 14 ],
   "sf_chart" : "Response Size",
   "sf_chartIndex" : 1528139299895,
   "sf_description" : "Average size of responses compared with -24h average",
@@ -2815,7 +3171,7 @@
         "direction" : {
           "options" : {
             "aggregateGroupBy" : [ {
-              "value" : "api_name"
+              "value" : "route_id"
             } ],
             "collapseGroups" : false,
             "transformTimeRange" : null
@@ -2829,7 +3185,7 @@
         "showMe" : false
       } ],
       "invisible" : true,
-      "name" : "counter.kong.responses.size - Sum by api_name",
+      "name" : "counter.kong.responses.size - Sum by route_id",
       "queryItems" : [ {
         "NOT" : false,
         "iconClass" : "icon-properties",
@@ -2840,7 +3196,7 @@
       }, {
         "NOT" : false,
         "iconClass" : "icon-properties",
-        "property" : "api_name",
+        "property" : "route_id",
         "propertyValue" : "*",
         "type" : "property",
         "value" : "*"
@@ -2865,7 +3221,7 @@
         "direction" : {
           "options" : {
             "aggregateGroupBy" : [ {
-              "value" : "api_name"
+              "value" : "route_id"
             } ],
             "collapseGroups" : false,
             "transformTimeRange" : null
@@ -2880,7 +3236,7 @@
       } ],
       "invisible" : true,
       "metricDefinition" : { },
-      "name" : "counter.kong.responses.count - Sum by api_name",
+      "name" : "counter.kong.responses.count - Sum by route_id",
       "queryItems" : [ {
         "NOT" : false,
         "iconClass" : "icon-properties",
@@ -2891,7 +3247,7 @@
       }, {
         "NOT" : false,
         "iconClass" : "icon-properties",
-        "property" : "api_name",
+        "property" : "route_id",
         "propertyValue" : "*",
         "type" : "property",
         "value" : "*"
@@ -3112,320 +3468,11 @@
     },
     "currentUniqueKey" : 24,
     "relatedDetectors" : [ ],
-    "revisionNumber" : 38,
-    "uiHelperValue" : "##CHARTID##_38"
+    "revisionNumber" : 42,
+    "uiHelperValue" : "##CHARTID##_42"
   }
 }, {
-  "marshallId" : 16,
-  "marshallMemberOf" : [ 14 ],
-  "sf_chart" : "Upstream Latency",
-  "sf_chartIndex" : 1528135368079,
-  "sf_description" : "Average latency for upstream responses compared with -24h average",
-  "sf_type" : "Chart",
-  "sf_uiModel" : {
-    "allPlots" : [ {
-      "_originalLabel" : "J",
-      "configuration" : {
-        "aliases" : { },
-        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
-        "maxExtrapolations" : -1,
-        "prefix" : "",
-        "rollupPolicy" : "LATEST_ROLLUP",
-        "suffix" : "",
-        "unitType" : "Millisecond"
-      },
-      "dataManipulations" : [ {
-        "direction" : {
-          "options" : {
-            "aggregateGroupBy" : [ {
-              "value" : "api_name"
-            } ],
-            "collapseGroups" : false,
-            "transformTimeRange" : null
-          },
-          "type" : "aggregation"
-        },
-        "fn" : {
-          "options" : { },
-          "type" : "SUM"
-        },
-        "showMe" : false
-      } ],
-      "invisible" : true,
-      "name" : "counter.kong.upstream.latency - Sum by api_name",
-      "queryItems" : [ {
-        "NOT" : false,
-        "iconClass" : "icon-properties",
-        "property" : "plugin",
-        "propertyValue" : "kong",
-        "type" : "property",
-        "value" : "kong"
-      }, {
-        "NOT" : false,
-        "iconClass" : "icon-properties",
-        "property" : "api_name",
-        "propertyValue" : "*",
-        "type" : "property",
-        "value" : "*"
-      } ],
-      "seriesData" : {
-        "metric" : "counter.kong.upstream.latency",
-        "regExStyle" : null
-      },
-      "transient" : false,
-      "type" : "plot",
-      "uniqueKey" : 10,
-      "yAxisIndex" : 0
-    }, {
-      "_originalLabel" : "K",
-      "configuration" : {
-        "aliases" : { },
-        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
-        "maxExtrapolations" : -1,
-        "rollupPolicy" : "LATEST_ROLLUP"
-      },
-      "dataManipulations" : [ {
-        "direction" : {
-          "options" : {
-            "aggregateGroupBy" : [ {
-              "value" : "api_name"
-            } ],
-            "collapseGroups" : false,
-            "transformTimeRange" : null
-          },
-          "type" : "aggregation"
-        },
-        "fn" : {
-          "options" : { },
-          "type" : "SUM"
-        },
-        "showMe" : false
-      } ],
-      "invisible" : true,
-      "metricDefinition" : { },
-      "name" : "counter.kong.responses.count - Sum by api_name",
-      "queryItems" : [ {
-        "NOT" : false,
-        "iconClass" : "icon-properties",
-        "property" : "plugin",
-        "propertyValue" : "kong",
-        "type" : "property",
-        "value" : "kong"
-      }, {
-        "NOT" : false,
-        "iconClass" : "icon-properties",
-        "property" : "api_name",
-        "propertyValue" : "*",
-        "type" : "property",
-        "value" : "*"
-      } ],
-      "seriesData" : {
-        "metric" : "counter.kong.responses.count",
-        "regExStyle" : null
-      },
-      "transient" : false,
-      "type" : "plot",
-      "uniqueKey" : 11,
-      "yAxisIndex" : 0
-    }, {
-      "_originalLabel" : "L",
-      "configuration" : {
-        "aliases" : { },
-        "colorOverride" : null,
-        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
-        "maxExtrapolations" : -1,
-        "prefix" : "",
-        "suffix" : "",
-        "unitType" : "Millisecond"
-      },
-      "dataManipulations" : [ ],
-      "expressionText" : "J / K",
-      "invisible" : false,
-      "metricDefinition" : { },
-      "name" : "latency",
-      "queryItems" : [ ],
-      "seriesData" : {
-        "metric" : null
-      },
-      "transient" : false,
-      "type" : "ratio",
-      "uniqueKey" : 12,
-      "valid" : true,
-      "yAxisIndex" : 0
-    }, {
-      "_originalLabel" : "O",
-      "configuration" : {
-        "aliases" : { },
-        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
-        "maxExtrapolations" : -1
-      },
-      "dataManipulations" : [ {
-        "direction" : {
-          "options" : {
-            "aggregateGroupBy" : [ ],
-            "collapseGroups" : false,
-            "transformTimeRange" : null
-          },
-          "type" : "aggregation"
-        },
-        "fn" : {
-          "options" : { },
-          "type" : "SUM"
-        },
-        "showMe" : false
-      } ],
-      "expressionText" : "J",
-      "invisible" : true,
-      "metricDefinition" : { },
-      "name" : "J - Sum",
-      "queryItems" : [ ],
-      "seriesData" : {
-        "metric" : null
-      },
-      "transient" : false,
-      "type" : "ratio",
-      "uniqueKey" : 15,
-      "valid" : true,
-      "yAxisIndex" : 0
-    }, {
-      "_originalLabel" : "P",
-      "configuration" : {
-        "aliases" : { },
-        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
-        "maxExtrapolations" : -1
-      },
-      "dataManipulations" : [ {
-        "direction" : {
-          "options" : {
-            "aggregateGroupBy" : [ ],
-            "collapseGroups" : false,
-            "transformTimeRange" : null
-          },
-          "type" : "aggregation"
-        },
-        "fn" : {
-          "options" : { },
-          "type" : "SUM"
-        },
-        "showMe" : false
-      } ],
-      "expressionText" : "K",
-      "invisible" : true,
-      "metricDefinition" : { },
-      "name" : "K - Sum",
-      "queryItems" : [ ],
-      "seriesData" : {
-        "metric" : null
-      },
-      "transient" : false,
-      "type" : "ratio",
-      "uniqueKey" : 16,
-      "valid" : true,
-      "yAxisIndex" : 0
-    }, {
-      "_originalLabel" : "Q",
-      "configuration" : {
-        "aliases" : { },
-        "colorOverride" : null,
-        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
-        "maxExtrapolations" : -1,
-        "prefix" : "",
-        "suffix" : "",
-        "unitType" : "Millisecond",
-        "visualization" : "line"
-      },
-      "dataManipulations" : [ {
-        "direction" : {
-          "options" : {
-            "aggregateGroupBy" : [ ],
-            "collapseGroups" : false,
-            "transformTimeRange" : null
-          },
-          "type" : "aggregation"
-        },
-        "fn" : {
-          "options" : {
-            "milliseconds" : 86400000
-          },
-          "type" : "TIMESHIFT"
-        },
-        "showMe" : false
-      } ],
-      "expressionText" : "O/P",
-      "invisible" : false,
-      "metricDefinition" : { },
-      "name" : "latency (historic)",
-      "queryItems" : [ ],
-      "seriesData" : {
-        "metric" : null
-      },
-      "transient" : false,
-      "type" : "ratio",
-      "uniqueKey" : 17,
-      "valid" : true,
-      "yAxisIndex" : 1
-    }, {
-      "configuration" : {
-        "aliases" : { },
-        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
-        "maxExtrapolations" : -1
-      },
-      "dataManipulations" : [ ],
-      "invisible" : false,
-      "metricDefinition" : { },
-      "name" : "New Plot",
-      "queryItems" : [ ],
-      "seriesData" : { },
-      "transient" : true,
-      "type" : "plot",
-      "uniqueKey" : 18,
-      "yAxisIndex" : 0
-    } ],
-    "chartMode" : "graph",
-    "chartType" : "heatmap",
-    "chartconfig" : {
-      "absoluteEnd" : null,
-      "absoluteStart" : null,
-      "colorByMetric" : false,
-      "colorByValue" : false,
-      "colorByValueScale" : [ ],
-      "histogramColor" : "#a747ff",
-      "range" : -1800000,
-      "rangeEnd" : 0,
-      "secondaryVisualization" : "SPARKLINE",
-      "sortPreference" : "-value",
-      "stackedChart" : false,
-      "useKMG2" : false,
-      "yAxisConfigurations" : [ {
-        "id" : "yAxis0",
-        "label" : "latency/resp",
-        "max" : null,
-        "min" : null,
-        "name" : "yAxis0",
-        "plotlines" : {
-          "high" : null,
-          "low" : null
-        }
-      }, {
-        "label" : "latency/resp",
-        "max" : null,
-        "min" : null,
-        "plotlines" : {
-          "high" : null,
-          "low" : null
-        },
-        "title" : {
-          "text" : ""
-        }
-      } ]
-    },
-    "currentUniqueKey" : 19,
-    "relatedDetectors" : [ ],
-    "revisionNumber" : 33,
-    "uiHelperValue" : "##CHARTID##_33"
-  }
-}, {
-  "marshallId" : 17,
+  "marshallId" : 18,
   "marshallMemberOf" : [ 14 ],
   "sf_chart" : "Kong Latency",
   "sf_chartIndex" : 1528147046843,
@@ -3447,7 +3494,7 @@
         "direction" : {
           "options" : {
             "aggregateGroupBy" : [ {
-              "value" : "api_name"
+              "value" : "route_id"
             } ],
             "collapseGroups" : false,
             "transformTimeRange" : null
@@ -3461,7 +3508,7 @@
         "showMe" : false
       } ],
       "invisible" : true,
-      "name" : "counter.kong.kong.latency - Sum by api_name",
+      "name" : "counter.kong.kong.latency - Sum by route_id",
       "queryItems" : [ {
         "NOT" : false,
         "iconClass" : "icon-properties",
@@ -3472,7 +3519,7 @@
       }, {
         "NOT" : false,
         "iconClass" : "icon-properties",
-        "property" : "api_name",
+        "property" : "route_id",
         "propertyValue" : "*",
         "type" : "property",
         "value" : "*"
@@ -3498,7 +3545,7 @@
         "direction" : {
           "options" : {
             "aggregateGroupBy" : [ {
-              "value" : "api_name"
+              "value" : "route_id"
             } ],
             "collapseGroups" : false,
             "transformTimeRange" : null
@@ -3513,7 +3560,7 @@
       } ],
       "invisible" : true,
       "metricDefinition" : { },
-      "name" : "counter.kong.responses.count - Sum by api_name",
+      "name" : "counter.kong.responses.count - Sum by route_id",
       "queryItems" : [ {
         "NOT" : false,
         "iconClass" : "icon-properties",
@@ -3524,7 +3571,7 @@
       }, {
         "NOT" : false,
         "iconClass" : "icon-properties",
-        "property" : "api_name",
+        "property" : "route_id",
         "propertyValue" : "*",
         "type" : "property",
         "value" : "*"
@@ -3739,229 +3786,11 @@
     },
     "currentUniqueKey" : 19,
     "relatedDetectors" : [ ],
-    "revisionNumber" : 27,
-    "uiHelperValue" : "##CHARTID##_27"
-  }
-}, {
-  "marshallId" : 18,
-  "marshallMemberOf" : [ 14 ],
-  "sf_chart" : "Responses / Second",
-  "sf_chartIndex" : 1528134810674,
-  "sf_description" : "Rate of API responses",
-  "sf_type" : "Chart",
-  "sf_uiModel" : {
-    "allPlots" : [ {
-      "_originalLabel" : "A",
-      "configuration" : {
-        "aliases" : { },
-        "colorOverride" : "#0077c2",
-        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
-        "maxExtrapolations" : -1,
-        "prefix" : "",
-        "suffix" : "",
-        "unitType" : null
-      },
-      "dataManipulations" : [ {
-        "direction" : {
-          "options" : {
-            "aggregateGroupBy" : [ ],
-            "collapseGroups" : false,
-            "transformTimeRange" : null
-          },
-          "type" : "aggregation"
-        },
-        "fn" : {
-          "options" : { },
-          "type" : "SUM"
-        },
-        "showMe" : false
-      } ],
-      "invisible" : false,
-      "name" : "responses",
-      "queryItems" : [ {
-        "NOT" : false,
-        "iconClass" : "sf-icon-property",
-        "property" : "plugin",
-        "propertyValue" : "kong",
-        "query" : "plugin:\"kong\"",
-        "type" : "property",
-        "value" : "kong"
-      }, {
-        "NOT" : false,
-        "iconClass" : "icon-properties",
-        "property" : "api_name",
-        "propertyValue" : "*",
-        "type" : "property",
-        "value" : "*"
-      } ],
-      "seriesData" : {
-        "metric" : "counter.kong.responses.count"
-      },
-      "transient" : false,
-      "type" : "plot",
-      "uniqueKey" : 1,
-      "yAxisIndex" : 0
-    }, {
-      "configuration" : {
-        "aliases" : { },
-        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
-        "maxExtrapolations" : -1
-      },
-      "dataManipulations" : [ ],
-      "invisible" : false,
-      "metricDefinition" : { },
-      "name" : "New Plot",
-      "queryItems" : [ ],
-      "seriesData" : { },
-      "transient" : true,
-      "type" : "plot",
-      "uniqueKey" : 2,
-      "yAxisIndex" : 0
-    } ],
-    "chartMode" : "single",
-    "chartType" : "line",
-    "chartconfig" : {
-      "absoluteEnd" : null,
-      "absoluteStart" : null,
-      "colorByMetric" : false,
-      "colorByValue" : false,
-      "colorByValueScale" : [ ],
-      "hideTimestamp" : false,
-      "histogramColor" : "#ea1849",
-      "maxDecimalPlaces" : 2,
-      "range" : -1800000,
-      "rangeEnd" : 0,
-      "secondaryVisualization" : "NONE",
-      "sortPreference" : "",
-      "useKMG2" : false,
-      "yAxisConfigurations" : [ {
-        "id" : "yAxis0",
-        "max" : null,
-        "min" : null,
-        "name" : "yAxis0",
-        "plotlines" : {
-          "high" : null,
-          "low" : null
-        }
-      } ]
-    },
-    "currentUniqueKey" : 3,
-    "relatedDetectors" : [ ],
-    "revisionNumber" : 20,
-    "uiHelperValue" : "##CHARTID##_20"
+    "revisionNumber" : 30,
+    "uiHelperValue" : "##CHARTID##_30"
   }
 }, {
   "marshallId" : 19,
-  "marshallMemberOf" : [ 14 ],
-  "sf_chart" : "Requests by HTTP Method",
-  "sf_chartIndex" : 1528138165800,
-  "sf_description" : "Number of API-fielded requests per interval by HTTP method",
-  "sf_type" : "Chart",
-  "sf_uiModel" : {
-    "allPlots" : [ {
-      "_originalLabel" : "A",
-      "configuration" : {
-        "aliases" : { },
-        "colorOverride" : null,
-        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
-        "maxExtrapolations" : -1,
-        "rollupPolicy" : "DELTA_ROLLUP",
-        "suffix" : "requests",
-        "unitType" : null
-      },
-      "dataManipulations" : [ {
-        "direction" : {
-          "options" : {
-            "aggregateGroupBy" : [ {
-              "value" : "http_method"
-            } ],
-            "collapseGroups" : false,
-            "transformTimeRange" : null
-          },
-          "type" : "aggregation"
-        },
-        "fn" : {
-          "options" : { },
-          "type" : "SUM"
-        },
-        "showMe" : false
-      } ],
-      "invisible" : false,
-      "name" : "counter.kong.responses.count - Sum by http_method",
-      "queryItems" : [ {
-        "NOT" : false,
-        "iconClass" : "icon-properties",
-        "property" : "plugin",
-        "propertyValue" : "kong",
-        "type" : "property",
-        "value" : "kong"
-      }, {
-        "NOT" : false,
-        "iconClass" : "icon-properties",
-        "property" : "api_name",
-        "propertyValue" : "*",
-        "type" : "property",
-        "value" : "*"
-      } ],
-      "seriesData" : {
-        "metric" : "counter.kong.responses.count"
-      },
-      "transient" : false,
-      "type" : "plot",
-      "uniqueKey" : 1,
-      "yAxisIndex" : 0
-    }, {
-      "configuration" : {
-        "aliases" : { },
-        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
-        "maxExtrapolations" : -1
-      },
-      "dataManipulations" : [ ],
-      "invisible" : false,
-      "metricDefinition" : { },
-      "name" : "New Plot",
-      "queryItems" : [ ],
-      "seriesData" : { },
-      "transient" : true,
-      "type" : "plot",
-      "uniqueKey" : 18,
-      "yAxisIndex" : 0
-    } ],
-    "chartMode" : "graph",
-    "chartType" : "column",
-    "chartconfig" : {
-      "absoluteEnd" : null,
-      "absoluteStart" : null,
-      "colorByMetric" : false,
-      "colorByValue" : false,
-      "colorByValueScale" : [ ],
-      "histogramColor" : "#ea1849",
-      "maxDecimalPlaces" : 4,
-      "range" : -1800000,
-      "rangeEnd" : 0,
-      "secondaryVisualization" : "SPARKLINE",
-      "sortPreference" : "+http_method",
-      "stackedChart" : true,
-      "useKMG2" : false,
-      "yAxisConfigurations" : [ {
-        "id" : "yAxis0",
-        "label" : "req/intvl",
-        "max" : null,
-        "min" : null,
-        "name" : "yAxis0",
-        "plotlines" : {
-          "high" : null,
-          "low" : null
-        }
-      } ]
-    },
-    "currentUniqueKey" : 19,
-    "relatedDetectors" : [ ],
-    "revisionNumber" : 28,
-    "uiHelperValue" : "##CHARTID##_28"
-  }
-}, {
-  "marshallId" : 20,
   "marshallMemberOf" : [ 14 ],
   "sf_chart" : "Responses / Second",
   "sf_chartIndex" : 1528219376990,
@@ -3983,7 +3812,7 @@
         "direction" : {
           "options" : {
             "aggregateGroupBy" : [ {
-              "value" : "api_name"
+              "value" : "route_id"
             } ],
             "collapseGroups" : false,
             "transformTimeRange" : null
@@ -4009,7 +3838,7 @@
       }, {
         "NOT" : false,
         "iconClass" : "icon-properties",
-        "property" : "api_name",
+        "property" : "route_id",
         "propertyValue" : "*",
         "type" : "property",
         "value" : "*"
@@ -4137,15 +3966,15 @@
     },
     "currentUniqueKey" : 5,
     "relatedDetectors" : [ ],
-    "revisionNumber" : 36,
-    "uiHelperValue" : "##CHARTID##_36"
+    "revisionNumber" : 38,
+    "uiHelperValue" : "##CHARTID##_38"
   }
 }, {
-  "marshallId" : 21,
+  "marshallId" : 20,
   "marshallMemberOf" : [ 14 ],
   "sf_chart" : "Request Size",
   "sf_chartIndex" : 1528146664212,
-  "sf_description" : "Average size of API-fielded client requests compared with -24h average",
+  "sf_description" : "Average size of Route-fielded client requests compared with -24h average",
   "sf_type" : "Chart",
   "sf_uiModel" : {
     "allPlots" : [ {
@@ -4165,7 +3994,7 @@
         "direction" : {
           "options" : {
             "aggregateGroupBy" : [ {
-              "value" : "api_name"
+              "value" : "route_id"
             } ],
             "collapseGroups" : false,
             "transformTimeRange" : null
@@ -4179,7 +4008,7 @@
         "showMe" : false
       } ],
       "invisible" : true,
-      "name" : "counter.kong.requests.size - Sum by api_name",
+      "name" : "counter.kong.requests.size - Sum by route_id",
       "queryItems" : [ {
         "NOT" : false,
         "iconClass" : "icon-properties",
@@ -4190,7 +4019,7 @@
       }, {
         "NOT" : false,
         "iconClass" : "icon-properties",
-        "property" : "api_name",
+        "property" : "route_id",
         "propertyValue" : "*",
         "type" : "property",
         "value" : "*"
@@ -4219,7 +4048,7 @@
         "direction" : {
           "options" : {
             "aggregateGroupBy" : [ {
-              "value" : "api_name"
+              "value" : "route_id"
             } ],
             "collapseGroups" : false,
             "transformTimeRange" : null
@@ -4233,7 +4062,7 @@
         "showMe" : false
       } ],
       "invisible" : true,
-      "name" : "counter.kong.responses.count - Sum by api_name",
+      "name" : "counter.kong.responses.count - Sum by route_id",
       "queryItems" : [ {
         "NOT" : false,
         "iconClass" : "icon-properties",
@@ -4244,7 +4073,7 @@
       }, {
         "NOT" : false,
         "iconClass" : "icon-properties",
-        "property" : "api_name",
+        "property" : "route_id",
         "propertyValue" : "*",
         "type" : "property",
         "value" : "*"
@@ -4453,470 +4282,121 @@
     },
     "currentUniqueKey" : 20,
     "relatedDetectors" : [ ],
-    "revisionNumber" : 33,
-    "uiHelperValue" : "##CHARTID##_33"
+    "revisionNumber" : 35,
+    "uiHelperValue" : "##CHARTID##_35"
+  }
+}, {
+  "marshallId" : 21,
+  "marshallMemberOf" : [ 14 ],
+  "sf_chart" : "Requests by HTTP Method",
+  "sf_chartIndex" : 1528138165800,
+  "sf_description" : "Number of Route-fielded requests per interval by HTTP method",
+  "sf_type" : "Chart",
+  "sf_uiModel" : {
+    "allPlots" : [ {
+      "_originalLabel" : "A",
+      "configuration" : {
+        "aliases" : { },
+        "colorOverride" : null,
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
+        "maxExtrapolations" : -1,
+        "rollupPolicy" : "DELTA_ROLLUP",
+        "suffix" : "requests",
+        "unitType" : null
+      },
+      "dataManipulations" : [ {
+        "direction" : {
+          "options" : {
+            "aggregateGroupBy" : [ {
+              "value" : "http_method"
+            } ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          },
+          "type" : "aggregation"
+        },
+        "fn" : {
+          "options" : { },
+          "type" : "SUM"
+        },
+        "showMe" : false
+      } ],
+      "invisible" : false,
+      "name" : "",
+      "queryItems" : [ {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "plugin",
+        "propertyValue" : "kong",
+        "type" : "property",
+        "value" : "kong"
+      }, {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "route_id",
+        "propertyValue" : "*",
+        "type" : "property",
+        "value" : "*"
+      } ],
+      "seriesData" : {
+        "metric" : "counter.kong.responses.count"
+      },
+      "transient" : false,
+      "type" : "plot",
+      "uniqueKey" : 1,
+      "yAxisIndex" : 0
+    }, {
+      "configuration" : {
+        "aliases" : { },
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
+        "maxExtrapolations" : -1
+      },
+      "dataManipulations" : [ ],
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "New Plot",
+      "queryItems" : [ ],
+      "seriesData" : { },
+      "transient" : true,
+      "type" : "plot",
+      "uniqueKey" : 18,
+      "yAxisIndex" : 0
+    } ],
+    "chartMode" : "graph",
+    "chartType" : "column",
+    "chartconfig" : {
+      "absoluteEnd" : null,
+      "absoluteStart" : null,
+      "colorByMetric" : false,
+      "colorByValue" : false,
+      "colorByValueScale" : [ ],
+      "histogramColor" : "#ea1849",
+      "maxDecimalPlaces" : 4,
+      "range" : -1800000,
+      "rangeEnd" : 0,
+      "secondaryVisualization" : "SPARKLINE",
+      "sortPreference" : "+http_method",
+      "stackedChart" : true,
+      "useKMG2" : false,
+      "yAxisConfigurations" : [ {
+        "id" : "yAxis0",
+        "label" : "req/intvl",
+        "max" : null,
+        "min" : null,
+        "name" : "yAxis0",
+        "plotlines" : {
+          "high" : null,
+          "low" : null
+        }
+      } ]
+    },
+    "currentUniqueKey" : 19,
+    "relatedDetectors" : [ ],
+    "revisionNumber" : 29,
+    "uiHelperValue" : "##CHARTID##_29"
   }
 }, {
   "marshallId" : 22,
-  "marshallMemberOf" : [ 14 ],
-  "sf_chart" : "Responses",
-  "sf_chartIndex" : 1528304230699,
-  "sf_description" : "Within past hour",
-  "sf_type" : "Chart",
-  "sf_uiModel" : {
-    "allPlots" : [ {
-      "_originalLabel" : "A",
-      "configuration" : {
-        "aliases" : { },
-        "colorOverride" : null,
-        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
-        "maxExtrapolations" : -1,
-        "prefix" : "",
-        "rollupPolicy" : "SUM_ROLLUP",
-        "suffix" : "",
-        "unitType" : null
-      },
-      "dataManipulations" : [ {
-        "direction" : {
-          "options" : {
-            "aggregateGroupBy" : [ ],
-            "collapseGroups" : false,
-            "transformTimeRange" : null
-          },
-          "type" : "aggregation"
-        },
-        "fn" : {
-          "options" : { },
-          "type" : "SUM"
-        },
-        "showMe" : false
-      } ],
-      "invisible" : true,
-      "name" : "counter.kong.responses.count - Sum",
-      "queryItems" : [ {
-        "NOT" : false,
-        "iconClass" : "sf-icon-property",
-        "property" : "plugin",
-        "propertyValue" : "kong",
-        "query" : "plugin:\"kong\"",
-        "type" : "property",
-        "value" : "kong"
-      }, {
-        "NOT" : false,
-        "iconClass" : "icon-properties",
-        "property" : "api_name",
-        "propertyValue" : "*",
-        "type" : "property",
-        "value" : "*"
-      } ],
-      "seriesData" : {
-        "metric" : "counter.kong.responses.count"
-      },
-      "transient" : false,
-      "type" : "plot",
-      "uniqueKey" : 1,
-      "yAxisIndex" : 0
-    }, {
-      "_originalLabel" : "B",
-      "configuration" : {
-        "aliases" : { },
-        "colorOverride" : null,
-        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
-        "maxExtrapolations" : -1,
-        "prefix" : "",
-        "rollupPolicy" : "SUM_ROLLUP",
-        "suffix" : "",
-        "unitType" : null
-      },
-      "dataManipulations" : [ {
-        "direction" : {
-          "options" : {
-            "aggregateGroupBy" : [ ],
-            "collapseGroups" : false,
-            "transformTimeRange" : null
-          },
-          "type" : "aggregation"
-        },
-        "fn" : {
-          "options" : {
-            "milliseconds" : 3600000
-          },
-          "type" : "TIMESHIFT"
-        },
-        "showMe" : false
-      }, {
-        "direction" : {
-          "options" : {
-            "aggregateGroupBy" : [ ],
-            "collapseGroups" : false,
-            "transformTimeRange" : null
-          },
-          "type" : "aggregation"
-        },
-        "fn" : {
-          "options" : { },
-          "type" : "SUM"
-        },
-        "showMe" : false
-      } ],
-      "invisible" : true,
-      "name" : "counter.kong.responses.count - Timeshift 1h - Sum",
-      "queryItems" : [ {
-        "NOT" : false,
-        "iconClass" : "sf-icon-property",
-        "property" : "plugin",
-        "propertyValue" : "kong",
-        "query" : "plugin:\"kong\"",
-        "type" : "property",
-        "value" : "kong"
-      }, {
-        "NOT" : false,
-        "iconClass" : "icon-properties",
-        "property" : "api_name",
-        "propertyValue" : "*",
-        "type" : "property",
-        "value" : "*"
-      } ],
-      "seriesData" : {
-        "metric" : "counter.kong.responses.count"
-      },
-      "transient" : false,
-      "type" : "plot",
-      "uniqueKey" : 2,
-      "yAxisIndex" : 0
-    }, {
-      "_originalLabel" : "C",
-      "configuration" : {
-        "aliases" : { },
-        "colorOverride" : "#00b9ff",
-        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
-        "maxExtrapolations" : -1
-      },
-      "dataManipulations" : [ ],
-      "expressionText" : "A-B",
-      "invisible" : false,
-      "metricDefinition" : { },
-      "name" : "within past hour",
-      "queryItems" : [ ],
-      "seriesData" : {
-        "metric" : null
-      },
-      "transient" : false,
-      "type" : "ratio",
-      "uniqueKey" : 3,
-      "valid" : true,
-      "yAxisIndex" : 0
-    }, {
-      "configuration" : {
-        "aliases" : { },
-        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
-        "maxExtrapolations" : -1
-      },
-      "dataManipulations" : [ ],
-      "invisible" : false,
-      "metricDefinition" : { },
-      "name" : "New Plot",
-      "queryItems" : [ ],
-      "seriesData" : { },
-      "transient" : true,
-      "type" : "plot",
-      "uniqueKey" : 4,
-      "yAxisIndex" : 0
-    } ],
-    "chartMode" : "single",
-    "chartType" : "line",
-    "chartconfig" : {
-      "absoluteEnd" : null,
-      "absoluteStart" : null,
-      "colorByMetric" : false,
-      "colorByValue" : false,
-      "colorByValueScale" : [ ],
-      "hideTimestamp" : false,
-      "histogramColor" : "#ea1849",
-      "maxDecimalPlaces" : 2,
-      "range" : -1800000,
-      "rangeEnd" : 0,
-      "secondaryVisualization" : "NONE",
-      "sortPreference" : "",
-      "useKMG2" : false,
-      "yAxisConfigurations" : [ {
-        "id" : "yAxis0",
-        "max" : null,
-        "min" : null,
-        "name" : "yAxis0",
-        "plotlines" : {
-          "high" : null,
-          "low" : null
-        }
-      } ]
-    },
-    "currentUniqueKey" : 5,
-    "relatedDetectors" : [ ],
-    "revisionNumber" : 23,
-    "uiHelperValue" : "##CHARTID##_23"
-  }
-}, {
-  "marshallId" : 23,
-  "marshallMemberOf" : [ 14 ],
-  "sf_chart" : "4xx Responses by HTTP Method",
-  "sf_chartIndex" : 1528312603879,
-  "sf_description" : "Number of 4xx errors per interval by HTTP method",
-  "sf_type" : "Chart",
-  "sf_uiModel" : {
-    "allPlots" : [ {
-      "_originalLabel" : "A",
-      "configuration" : {
-        "aliases" : { },
-        "colorOverride" : null,
-        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
-        "maxExtrapolations" : -1,
-        "rollupPolicy" : "DELTA_ROLLUP",
-        "suffix" : "errors",
-        "unitType" : null
-      },
-      "dataManipulations" : [ {
-        "direction" : {
-          "options" : {
-            "aggregateGroupBy" : [ {
-              "value" : "http_method"
-            }, {
-              "value" : "status_code"
-            } ],
-            "collapseGroups" : false,
-            "transformTimeRange" : null
-          },
-          "type" : "aggregation"
-        },
-        "fn" : {
-          "options" : { },
-          "type" : "SUM"
-        },
-        "showMe" : false
-      } ],
-      "invisible" : false,
-      "name" : "errors",
-      "queryItems" : [ {
-        "NOT" : false,
-        "iconClass" : "icon-properties",
-        "property" : "plugin",
-        "propertyValue" : "kong",
-        "type" : "property",
-        "value" : "kong"
-      }, {
-        "NOT" : false,
-        "iconClass" : "icon-properties",
-        "property" : "api_name",
-        "propertyValue" : "*",
-        "type" : "property",
-        "value" : "*"
-      }, {
-        "NOT" : false,
-        "iconClass" : "icon-properties",
-        "property" : "status_code",
-        "propertyValue" : "4*",
-        "type" : "property",
-        "value" : "201"
-      } ],
-      "seriesData" : {
-        "metric" : "counter.kong.responses.count",
-        "regExStyle" : null
-      },
-      "transient" : false,
-      "type" : "plot",
-      "uniqueKey" : 1,
-      "yAxisIndex" : 0
-    }, {
-      "configuration" : {
-        "aliases" : { },
-        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
-        "maxExtrapolations" : -1
-      },
-      "dataManipulations" : [ ],
-      "invisible" : false,
-      "metricDefinition" : { },
-      "name" : "New Plot",
-      "queryItems" : [ ],
-      "seriesData" : { },
-      "transient" : true,
-      "type" : "plot",
-      "uniqueKey" : 18,
-      "yAxisIndex" : 0
-    } ],
-    "chartMode" : "graph",
-    "chartType" : "column",
-    "chartconfig" : {
-      "absoluteEnd" : null,
-      "absoluteStart" : null,
-      "colorByMetric" : false,
-      "colorByValue" : false,
-      "colorByValueScale" : [ ],
-      "groupBy" : [ ],
-      "heatmapAutoGradients" : 5,
-      "heatmapColorRange" : { },
-      "heatmapSortBy" : {
-        "asc" : true,
-        "value" : { }
-      },
-      "heatmapUnitsPerRow" : 0,
-      "heatmapUseValueAsColor" : false,
-      "hideTimestamp" : false,
-      "histogramColor" : "#ea1849",
-      "maxDecimalPlaces" : 4,
-      "range" : -900000,
-      "rangeEnd" : 0,
-      "secondaryVisualization" : "SPARKLINE",
-      "sortPreference" : "",
-      "stackedChart" : true,
-      "useKMG2" : false,
-      "yAxisConfigurations" : [ {
-        "id" : "yAxis0",
-        "label" : "errors/intvl",
-        "max" : null,
-        "min" : null,
-        "name" : "yAxis0",
-        "plotlines" : {
-          "high" : null,
-          "low" : null
-        }
-      } ]
-    },
-    "currentUniqueKey" : 19,
-    "relatedDetectors" : [ ],
-    "revisionNumber" : 31,
-    "uiHelperValue" : "##CHARTID##_31"
-  }
-}, {
-  "marshallId" : 24,
-  "marshallMemberOf" : [ 14 ],
-  "sf_chart" : "5xx Responses by HTTP Method",
-  "sf_chartIndex" : 1528313719962,
-  "sf_description" : "Number of 5xx errors per interval by HTTP method",
-  "sf_type" : "Chart",
-  "sf_uiModel" : {
-    "allPlots" : [ {
-      "_originalLabel" : "A",
-      "configuration" : {
-        "aliases" : { },
-        "colorOverride" : null,
-        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
-        "maxExtrapolations" : -1,
-        "rollupPolicy" : "DELTA_ROLLUP",
-        "suffix" : "errors",
-        "unitType" : null
-      },
-      "dataManipulations" : [ {
-        "direction" : {
-          "options" : {
-            "aggregateGroupBy" : [ {
-              "value" : "http_method"
-            }, {
-              "value" : "status_code"
-            } ],
-            "collapseGroups" : false,
-            "transformTimeRange" : null
-          },
-          "type" : "aggregation"
-        },
-        "fn" : {
-          "options" : { },
-          "type" : "SUM"
-        },
-        "showMe" : false
-      } ],
-      "invisible" : false,
-      "name" : "errors",
-      "queryItems" : [ {
-        "NOT" : false,
-        "iconClass" : "icon-properties",
-        "property" : "plugin",
-        "propertyValue" : "kong",
-        "type" : "property",
-        "value" : "kong"
-      }, {
-        "NOT" : false,
-        "iconClass" : "icon-properties",
-        "property" : "api_name",
-        "propertyValue" : "*",
-        "type" : "property",
-        "value" : "*"
-      }, {
-        "NOT" : false,
-        "iconClass" : "icon-properties",
-        "property" : "status_code",
-        "propertyValue" : "5*",
-        "type" : "property",
-        "value" : "201"
-      } ],
-      "seriesData" : {
-        "metric" : "counter.kong.responses.count",
-        "regExStyle" : null
-      },
-      "transient" : false,
-      "type" : "plot",
-      "uniqueKey" : 1,
-      "yAxisIndex" : 0
-    }, {
-      "configuration" : {
-        "aliases" : { },
-        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
-        "maxExtrapolations" : -1
-      },
-      "dataManipulations" : [ ],
-      "invisible" : false,
-      "metricDefinition" : { },
-      "name" : "New Plot",
-      "queryItems" : [ ],
-      "seriesData" : { },
-      "transient" : true,
-      "type" : "plot",
-      "uniqueKey" : 18,
-      "yAxisIndex" : 0
-    } ],
-    "chartMode" : "graph",
-    "chartType" : "column",
-    "chartconfig" : {
-      "absoluteEnd" : null,
-      "absoluteStart" : null,
-      "colorByMetric" : false,
-      "colorByValue" : false,
-      "colorByValueScale" : [ ],
-      "groupBy" : [ ],
-      "heatmapAutoGradients" : 5,
-      "heatmapColorRange" : { },
-      "heatmapSortBy" : {
-        "asc" : true,
-        "value" : { }
-      },
-      "heatmapUnitsPerRow" : 0,
-      "heatmapUseValueAsColor" : false,
-      "hideTimestamp" : false,
-      "histogramColor" : "#ea1849",
-      "maxDecimalPlaces" : 4,
-      "range" : -300000,
-      "rangeEnd" : 0,
-      "secondaryVisualization" : "SPARKLINE",
-      "sortPreference" : "",
-      "stackedChart" : true,
-      "useKMG2" : false,
-      "yAxisConfigurations" : [ {
-        "id" : "yAxis0",
-        "label" : "errors/intvl",
-        "max" : null,
-        "min" : null,
-        "name" : "yAxis0",
-        "plotlines" : {
-          "high" : null,
-          "low" : null
-        }
-      } ]
-    },
-    "currentUniqueKey" : 19,
-    "relatedDetectors" : [ ],
-    "revisionNumber" : 27,
-    "uiHelperValue" : "##CHARTID##_27"
-  }
-}, {
-  "marshallId" : 25,
   "marshallMemberOf" : [ 14 ],
   "sf_chart" : "Responses by Status Code",
   "sf_chartIndex" : 1528136271804,
@@ -4970,7 +4450,7 @@
       }, {
         "NOT" : false,
         "iconClass" : "icon-properties",
-        "property" : "api_name",
+        "property" : "route_id",
         "propertyValue" : "*",
         "type" : "property",
         "value" : "*"
@@ -5028,7 +4508,7 @@
       }, {
         "NOT" : false,
         "iconClass" : "icon-properties",
-        "property" : "api_name",
+        "property" : "route_id",
         "propertyValue" : "*",
         "type" : "property",
         "value" : "*"
@@ -5086,7 +4566,7 @@
       }, {
         "NOT" : false,
         "iconClass" : "icon-properties",
-        "property" : "api_name",
+        "property" : "route_id",
         "propertyValue" : "*",
         "type" : "property",
         "value" : "*"
@@ -5145,7 +4625,7 @@
       }, {
         "NOT" : false,
         "iconClass" : "icon-properties",
-        "property" : "api_name",
+        "property" : "route_id",
         "propertyValue" : "*",
         "type" : "property",
         "value" : "*"
@@ -5202,9 +4682,12 @@
         "type" : "property",
         "value" : "5*"
       }, {
-        "property" : "api_name",
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "route_id",
         "propertyValue" : "*",
-        "type" : "property"
+        "type" : "property",
+        "value" : "*"
       } ],
       "seriesData" : {
         "metric" : "counter.kong.responses.count",
@@ -5271,29 +4754,565 @@
     },
     "currentUniqueKey" : 12,
     "relatedDetectors" : [ ],
-    "revisionNumber" : 23,
-    "uiHelperValue" : "##CHARTID##_23"
+    "revisionNumber" : 25,
+    "uiHelperValue" : "##CHARTID##_25"
+  }
+}, {
+  "marshallId" : 23,
+  "marshallMemberOf" : [ 14 ],
+  "sf_chart" : "Upstream Latency",
+  "sf_chartIndex" : 1528135368079,
+  "sf_description" : "Average latency for upstream responses compared with -24h average",
+  "sf_type" : "Chart",
+  "sf_uiModel" : {
+    "allPlots" : [ {
+      "_originalLabel" : "J",
+      "configuration" : {
+        "aliases" : { },
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
+        "maxExtrapolations" : -1,
+        "prefix" : "",
+        "rollupPolicy" : "LATEST_ROLLUP",
+        "suffix" : "",
+        "unitType" : "Millisecond"
+      },
+      "dataManipulations" : [ {
+        "direction" : {
+          "options" : {
+            "aggregateGroupBy" : [ {
+              "value" : "route_id"
+            } ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          },
+          "type" : "aggregation"
+        },
+        "fn" : {
+          "options" : { },
+          "type" : "SUM"
+        },
+        "showMe" : false
+      } ],
+      "invisible" : true,
+      "name" : "counter.kong.upstream.latency - Sum by route_id",
+      "queryItems" : [ {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "plugin",
+        "propertyValue" : "kong",
+        "type" : "property",
+        "value" : "kong"
+      }, {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "route_id",
+        "propertyValue" : "*",
+        "type" : "property",
+        "value" : "*"
+      } ],
+      "seriesData" : {
+        "metric" : "counter.kong.upstream.latency",
+        "regExStyle" : null
+      },
+      "transient" : false,
+      "type" : "plot",
+      "uniqueKey" : 10,
+      "yAxisIndex" : 0
+    }, {
+      "_originalLabel" : "K",
+      "configuration" : {
+        "aliases" : { },
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
+        "maxExtrapolations" : -1,
+        "rollupPolicy" : "LATEST_ROLLUP"
+      },
+      "dataManipulations" : [ {
+        "direction" : {
+          "options" : {
+            "aggregateGroupBy" : [ {
+              "value" : "route_id"
+            } ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          },
+          "type" : "aggregation"
+        },
+        "fn" : {
+          "options" : { },
+          "type" : "SUM"
+        },
+        "showMe" : false
+      } ],
+      "invisible" : true,
+      "metricDefinition" : { },
+      "name" : "counter.kong.responses.count - Sum by route_id",
+      "queryItems" : [ {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "plugin",
+        "propertyValue" : "kong",
+        "type" : "property",
+        "value" : "kong"
+      }, {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "route_id",
+        "propertyValue" : "*",
+        "type" : "property",
+        "value" : "*"
+      } ],
+      "seriesData" : {
+        "metric" : "counter.kong.responses.count",
+        "regExStyle" : null
+      },
+      "transient" : false,
+      "type" : "plot",
+      "uniqueKey" : 11,
+      "yAxisIndex" : 0
+    }, {
+      "_originalLabel" : "L",
+      "configuration" : {
+        "aliases" : { },
+        "colorOverride" : null,
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
+        "maxExtrapolations" : -1,
+        "prefix" : "",
+        "suffix" : "",
+        "unitType" : "Millisecond"
+      },
+      "dataManipulations" : [ ],
+      "expressionText" : "J / K",
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "latency",
+      "queryItems" : [ ],
+      "seriesData" : {
+        "metric" : null
+      },
+      "transient" : false,
+      "type" : "ratio",
+      "uniqueKey" : 12,
+      "valid" : true,
+      "yAxisIndex" : 0
+    }, {
+      "_originalLabel" : "O",
+      "configuration" : {
+        "aliases" : { },
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
+        "maxExtrapolations" : -1
+      },
+      "dataManipulations" : [ {
+        "direction" : {
+          "options" : {
+            "aggregateGroupBy" : [ ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          },
+          "type" : "aggregation"
+        },
+        "fn" : {
+          "options" : { },
+          "type" : "SUM"
+        },
+        "showMe" : false
+      } ],
+      "expressionText" : "J",
+      "invisible" : true,
+      "metricDefinition" : { },
+      "name" : "J - Sum",
+      "queryItems" : [ ],
+      "seriesData" : {
+        "metric" : null
+      },
+      "transient" : false,
+      "type" : "ratio",
+      "uniqueKey" : 15,
+      "valid" : true,
+      "yAxisIndex" : 0
+    }, {
+      "_originalLabel" : "P",
+      "configuration" : {
+        "aliases" : { },
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
+        "maxExtrapolations" : -1
+      },
+      "dataManipulations" : [ {
+        "direction" : {
+          "options" : {
+            "aggregateGroupBy" : [ ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          },
+          "type" : "aggregation"
+        },
+        "fn" : {
+          "options" : { },
+          "type" : "SUM"
+        },
+        "showMe" : false
+      } ],
+      "expressionText" : "K",
+      "invisible" : true,
+      "metricDefinition" : { },
+      "name" : "K - Sum",
+      "queryItems" : [ ],
+      "seriesData" : {
+        "metric" : null
+      },
+      "transient" : false,
+      "type" : "ratio",
+      "uniqueKey" : 16,
+      "valid" : true,
+      "yAxisIndex" : 0
+    }, {
+      "_originalLabel" : "Q",
+      "configuration" : {
+        "aliases" : { },
+        "colorOverride" : null,
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
+        "maxExtrapolations" : -1,
+        "prefix" : "",
+        "suffix" : "",
+        "unitType" : "Millisecond",
+        "visualization" : "line"
+      },
+      "dataManipulations" : [ {
+        "direction" : {
+          "options" : {
+            "aggregateGroupBy" : [ ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          },
+          "type" : "aggregation"
+        },
+        "fn" : {
+          "options" : {
+            "milliseconds" : 86400000
+          },
+          "type" : "TIMESHIFT"
+        },
+        "showMe" : false
+      } ],
+      "expressionText" : "O/P",
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "latency (historic)",
+      "queryItems" : [ ],
+      "seriesData" : {
+        "metric" : null
+      },
+      "transient" : false,
+      "type" : "ratio",
+      "uniqueKey" : 17,
+      "valid" : true,
+      "yAxisIndex" : 1
+    }, {
+      "configuration" : {
+        "aliases" : { },
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
+        "maxExtrapolations" : -1
+      },
+      "dataManipulations" : [ ],
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "New Plot",
+      "queryItems" : [ ],
+      "seriesData" : { },
+      "transient" : true,
+      "type" : "plot",
+      "uniqueKey" : 18,
+      "yAxisIndex" : 0
+    } ],
+    "chartMode" : "graph",
+    "chartType" : "heatmap",
+    "chartconfig" : {
+      "absoluteEnd" : null,
+      "absoluteStart" : null,
+      "colorByMetric" : false,
+      "colorByValue" : false,
+      "colorByValueScale" : [ ],
+      "histogramColor" : "#a747ff",
+      "range" : -1800000,
+      "rangeEnd" : 0,
+      "secondaryVisualization" : "SPARKLINE",
+      "sortPreference" : "-value",
+      "stackedChart" : false,
+      "useKMG2" : false,
+      "yAxisConfigurations" : [ {
+        "id" : "yAxis0",
+        "label" : "latency/resp",
+        "max" : null,
+        "min" : null,
+        "name" : "yAxis0",
+        "plotlines" : {
+          "high" : null,
+          "low" : null
+        }
+      }, {
+        "label" : "latency/resp",
+        "max" : null,
+        "min" : null,
+        "plotlines" : {
+          "high" : null,
+          "low" : null
+        },
+        "title" : {
+          "text" : ""
+        }
+      } ]
+    },
+    "currentUniqueKey" : 19,
+    "relatedDetectors" : [ ],
+    "revisionNumber" : 35,
+    "uiHelperValue" : "##CHARTID##_35"
+  }
+}, {
+  "marshallId" : 24,
+  "marshallMemberOf" : [ 14 ],
+  "sf_chart" : "Responses / Second",
+  "sf_chartIndex" : 1528134810674,
+  "sf_description" : "Rate of Route responses",
+  "sf_type" : "Chart",
+  "sf_uiModel" : {
+    "allPlots" : [ {
+      "_originalLabel" : "A",
+      "configuration" : {
+        "aliases" : { },
+        "colorOverride" : "#0077c2",
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
+        "maxExtrapolations" : -1,
+        "prefix" : "",
+        "suffix" : "",
+        "unitType" : null
+      },
+      "dataManipulations" : [ {
+        "direction" : {
+          "options" : {
+            "aggregateGroupBy" : [ ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          },
+          "type" : "aggregation"
+        },
+        "fn" : {
+          "options" : { },
+          "type" : "SUM"
+        },
+        "showMe" : false
+      } ],
+      "invisible" : false,
+      "name" : "responses",
+      "queryItems" : [ {
+        "NOT" : false,
+        "iconClass" : "sf-icon-property",
+        "property" : "plugin",
+        "propertyValue" : "kong",
+        "query" : "plugin:\"kong\"",
+        "type" : "property",
+        "value" : "kong"
+      }, {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "route_id",
+        "propertyValue" : "*",
+        "type" : "property",
+        "value" : "*"
+      } ],
+      "seriesData" : {
+        "metric" : "counter.kong.responses.count"
+      },
+      "transient" : false,
+      "type" : "plot",
+      "uniqueKey" : 1,
+      "yAxisIndex" : 0
+    }, {
+      "configuration" : {
+        "aliases" : { },
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
+        "maxExtrapolations" : -1
+      },
+      "dataManipulations" : [ ],
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "New Plot",
+      "queryItems" : [ ],
+      "seriesData" : { },
+      "transient" : true,
+      "type" : "plot",
+      "uniqueKey" : 2,
+      "yAxisIndex" : 0
+    } ],
+    "chartMode" : "single",
+    "chartType" : "line",
+    "chartconfig" : {
+      "absoluteEnd" : null,
+      "absoluteStart" : null,
+      "colorByMetric" : false,
+      "colorByValue" : false,
+      "colorByValueScale" : [ ],
+      "hideTimestamp" : false,
+      "histogramColor" : "#ea1849",
+      "maxDecimalPlaces" : 2,
+      "range" : -1800000,
+      "rangeEnd" : 0,
+      "secondaryVisualization" : "NONE",
+      "sortPreference" : "",
+      "useKMG2" : false,
+      "yAxisConfigurations" : [ {
+        "id" : "yAxis0",
+        "max" : null,
+        "min" : null,
+        "name" : "yAxis0",
+        "plotlines" : {
+          "high" : null,
+          "low" : null
+        }
+      } ]
+    },
+    "currentUniqueKey" : 3,
+    "relatedDetectors" : [ ],
+    "revisionNumber" : 22,
+    "uiHelperValue" : "##CHARTID##_22"
+  }
+}, {
+  "marshallId" : 25,
+  "marshallMemberOf" : [ 14 ],
+  "sf_chart" : "5xx Responses by HTTP Method",
+  "sf_chartIndex" : 1528313719962,
+  "sf_description" : "Number of 5xx errors per interval by HTTP method",
+  "sf_type" : "Chart",
+  "sf_uiModel" : {
+    "allPlots" : [ {
+      "_originalLabel" : "A",
+      "configuration" : {
+        "aliases" : { },
+        "colorOverride" : null,
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
+        "maxExtrapolations" : -1,
+        "rollupPolicy" : "DELTA_ROLLUP",
+        "suffix" : "errors",
+        "unitType" : null
+      },
+      "dataManipulations" : [ {
+        "direction" : {
+          "options" : {
+            "aggregateGroupBy" : [ {
+              "value" : "http_method"
+            }, {
+              "value" : "status_code"
+            } ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          },
+          "type" : "aggregation"
+        },
+        "fn" : {
+          "options" : { },
+          "type" : "SUM"
+        },
+        "showMe" : false
+      } ],
+      "invisible" : false,
+      "name" : "errors",
+      "queryItems" : [ {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "plugin",
+        "propertyValue" : "kong",
+        "type" : "property",
+        "value" : "kong"
+      }, {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "status_code",
+        "propertyValue" : "5*",
+        "type" : "property",
+        "value" : "201"
+      }, {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "route_id",
+        "propertyValue" : "*",
+        "type" : "property",
+        "value" : "*"
+      } ],
+      "seriesData" : {
+        "metric" : "counter.kong.responses.count",
+        "regExStyle" : null
+      },
+      "transient" : false,
+      "type" : "plot",
+      "uniqueKey" : 1,
+      "yAxisIndex" : 0
+    }, {
+      "configuration" : {
+        "aliases" : { },
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
+        "maxExtrapolations" : -1
+      },
+      "dataManipulations" : [ ],
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "New Plot",
+      "queryItems" : [ ],
+      "seriesData" : { },
+      "transient" : true,
+      "type" : "plot",
+      "uniqueKey" : 18,
+      "yAxisIndex" : 0
+    } ],
+    "chartMode" : "graph",
+    "chartType" : "column",
+    "chartconfig" : {
+      "absoluteEnd" : null,
+      "absoluteStart" : null,
+      "colorByMetric" : false,
+      "colorByValue" : false,
+      "colorByValueScale" : [ ],
+      "groupBy" : [ ],
+      "heatmapAutoGradients" : 5,
+      "heatmapColorRange" : { },
+      "heatmapSortBy" : {
+        "asc" : true,
+        "value" : { }
+      },
+      "heatmapUnitsPerRow" : 0,
+      "heatmapUseValueAsColor" : false,
+      "hideTimestamp" : false,
+      "histogramColor" : "#ea1849",
+      "maxDecimalPlaces" : 4,
+      "range" : -1800000,
+      "rangeEnd" : 0,
+      "secondaryVisualization" : "SPARKLINE",
+      "sortPreference" : "",
+      "stackedChart" : true,
+      "useKMG2" : false,
+      "yAxisConfigurations" : [ {
+        "id" : "yAxis0",
+        "label" : "errors/intvl",
+        "max" : null,
+        "min" : null,
+        "name" : "yAxis0",
+        "plotlines" : {
+          "high" : null,
+          "low" : null
+        }
+      } ]
+    },
+    "currentUniqueKey" : 19,
+    "relatedDetectors" : [ ],
+    "revisionNumber" : 29,
+    "uiHelperValue" : "##CHARTID##_29"
   }
 }, {
   "marshallId" : 26,
   "marshallMemberOf" : [ 1 ],
-  "sf_dashboard" : "Kong Server Overview",
-  "sf_description" : "High-level Kong performance for individual server",
+  "sf_dashboard" : "Kong Servers Overview",
+  "sf_description" : "High-level Kong performance for all reporting servers",
   "sf_discoveryQuery" : "plugin:kong",
   "sf_discoverySelectors" : [ "__exists__:host", "plugin:kong" ],
   "sf_filterAlias" : {
-    "variables" : [ {
-      "alias" : "Kong Instance",
-      "applyIfExists" : false,
-      "description" : "",
-      "dimension" : "host",
-      "globalScope" : false,
-      "preferredSuggestions" : [ ],
-      "replaceOnly" : false,
-      "required" : true,
-      "restricted" : false,
-      "value" : ""
-    } ]
+    "variables" : [ ]
   },
   "sf_isLocked" : false,
   "sf_maxDelayOverride" : -1,
@@ -5305,7 +5324,7 @@
       "relative" : true,
       "start" : "-1h"
     },
-    "variables" : [ "Kong Instance=host:" ]
+    "variables" : null
   },
   "sf_selectedEventOverlays" : [ ],
   "sf_type" : "Dashboard",
@@ -5314,12 +5333,12 @@
     "widgets" : [ {
       "col" : 0,
       "options" : {
-        "chartIndex" : 1528137157576,
+        "chartIndex" : 1528220571437,
         "id" : 0
       },
       "row" : 0,
       "sizeX" : 3,
-      "sizeY" : 2
+      "sizeY" : 1
     }, {
       "col" : 3,
       "options" : {
@@ -5339,9 +5358,9 @@
       "sizeX" : 6,
       "sizeY" : 1
     }, {
-      "col" : 3,
+      "col" : 0,
       "options" : {
-        "chartIndex" : 1528134810674,
+        "chartIndex" : 1528137157576,
         "id" : 0
       },
       "row" : 1,
@@ -5357,27 +5376,36 @@
       "sizeX" : 6,
       "sizeY" : 1
     }, {
+      "col" : 3,
+      "options" : {
+        "chartIndex" : 1528134810674,
+        "id" : 0
+      },
+      "row" : 1,
+      "sizeX" : 3,
+      "sizeY" : 1
+    }, {
       "col" : 0,
       "options" : {
-        "chartIndex" : 1528729931437,
+        "chartIndex" : 1528729536811,
         "id" : 0
       },
       "row" : 2,
       "sizeX" : 6,
       "sizeY" : 1
     }, {
-      "col" : 9,
+      "col" : 6,
       "options" : {
-        "chartIndex" : 1528135823509,
+        "chartIndex" : 1528138165800,
         "id" : 0
       },
       "row" : 2,
       "sizeX" : 3,
       "sizeY" : 2
     }, {
-      "col" : 6,
+      "col" : 9,
       "options" : {
-        "chartIndex" : 1528138165800,
+        "chartIndex" : 1528135823509,
         "id" : 0
       },
       "row" : 2,
@@ -5391,11 +5419,11 @@
       },
       "row" : 3,
       "sizeX" : 6,
-      "sizeY" : 2
+      "sizeY" : 1
     }, {
       "col" : 6,
       "options" : {
-        "chartIndex" : 1528311465641,
+        "chartIndex" : 1528311013969,
         "id" : 0
       },
       "row" : 4,
@@ -5404,10 +5432,10 @@
     }, {
       "col" : 0,
       "options" : {
-        "chartIndex" : 1528311465640,
+        "chartIndex" : 1528310523139,
         "id" : 0
       },
-      "row" : 5,
+      "row" : 4,
       "sizeX" : 6,
       "sizeY" : 1
     }, {
@@ -5418,34 +5446,34 @@
       },
       "row" : 5,
       "sizeX" : 6,
-      "sizeY" : 2
+      "sizeY" : 1
     }, {
       "col" : 0,
       "options" : {
         "chartIndex" : 1528139299895,
         "id" : 0
       },
-      "row" : 6,
+      "row" : 5,
       "sizeX" : 6,
-      "sizeY" : 2
+      "sizeY" : 1
     }, {
       "col" : 6,
       "options" : {
         "chartIndex" : 1528147046843,
         "id" : 0
       },
-      "row" : 7,
+      "row" : 6,
       "sizeX" : 6,
-      "sizeY" : 2
+      "sizeY" : 1
     }, {
       "col" : 0,
       "options" : {
         "chartIndex" : 1528135368079,
         "id" : 0
       },
-      "row" : 8,
+      "row" : 6,
       "sizeX" : 6,
-      "sizeY" : 2
+      "sizeY" : 1
     } ]
   }
 }, {
@@ -5527,7 +5555,7 @@
       "hideTimestamp" : false,
       "histogramColor" : "#ea1849",
       "maxDecimalPlaces" : 2,
-      "range" : -1800000,
+      "range" : -3600000,
       "rangeEnd" : 0,
       "secondaryVisualization" : "NONE",
       "sortPreference" : "",
@@ -5552,20 +5580,23 @@
 }, {
   "marshallId" : 28,
   "marshallMemberOf" : [ 26 ],
-  "sf_chart" : "Database Reachable",
-  "sf_chartIndex" : 1528137157576,
-  "sf_description" : "Connection status as reported by kong.dao",
+  "sf_chart" : "Response Size",
+  "sf_chartIndex" : 1528139299895,
+  "sf_description" : "Average size of response from Service/API compared with -24h",
   "sf_type" : "Chart",
   "sf_uiModel" : {
     "allPlots" : [ {
       "_originalLabel" : "A",
       "configuration" : {
         "aliases" : { },
-        "extrapolationPolicy" : "LAST_VALUE_EXTRAPOLATION",
+        "colorOverride" : null,
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
         "maxExtrapolations" : -1,
         "prefix" : "",
+        "rollupPolicy" : null,
         "suffix" : "",
-        "unitType" : null
+        "unitType" : "Byte",
+        "visualization" : null
       },
       "dataManipulations" : [ {
         "direction" : {
@@ -5580,133 +5611,12 @@
         },
         "fn" : {
           "options" : { },
-          "type" : "COUNT"
-        },
-        "showMe" : false
-      } ],
-      "invisible" : false,
-      "name" : "is reachable",
-      "queryItems" : [ {
-        "NOT" : false,
-        "iconClass" : "icon-properties",
-        "property" : "plugin",
-        "propertyValue" : "kong",
-        "type" : "property",
-        "value" : "kong"
-      } ],
-      "seriesData" : {
-        "metric" : "gauge.kong.database.reachable"
-      },
-      "transient" : false,
-      "type" : "plot",
-      "uniqueKey" : 1,
-      "yAxisIndex" : 0
-    }, {
-      "configuration" : {
-        "aliases" : { },
-        "extrapolationPolicy" : "LAST_VALUE_EXTRAPOLATION",
-        "maxExtrapolations" : -1
-      },
-      "dataManipulations" : [ ],
-      "invisible" : false,
-      "metricDefinition" : { },
-      "name" : "New Plot",
-      "queryItems" : [ ],
-      "seriesData" : { },
-      "transient" : true,
-      "type" : "plot",
-      "uniqueKey" : 2,
-      "yAxisIndex" : 0
-    } ],
-    "chartMode" : "heatmap",
-    "chartType" : null,
-    "chartconfig" : {
-      "absoluteEnd" : null,
-      "absoluteStart" : null,
-      "colorByMetric" : false,
-      "colorByValue" : true,
-      "colorByValueScale" : [ {
-        "color" : "#6bd37e",
-        "gte" : 1
-      }, {
-        "color" : "#ea1849",
-        "lt" : 1
-      } ],
-      "groupBy" : [ ],
-      "heatmapAutoGradients" : 5,
-      "heatmapColorOverride" : "#05ce00",
-      "heatmapColorRange" : {
-        "max" : 1,
-        "min" : 0
-      },
-      "heatmapSortBy" : {
-        "asc" : true,
-        "value" : { }
-      },
-      "heatmapUnitsPerRow" : 0,
-      "heatmapUseValueAsColor" : false,
-      "hideTimestamp" : false,
-      "histogramColor" : "#ea1849",
-      "range" : -1800000,
-      "rangeEnd" : 0,
-      "secondaryVisualization" : "NONE",
-      "sortPreference" : "",
-      "useKMG2" : false,
-      "yAxisConfigurations" : [ {
-        "id" : "yAxis0",
-        "max" : null,
-        "min" : null,
-        "name" : "yAxis0",
-        "plotlines" : {
-          "high" : null,
-          "low" : null
-        }
-      } ]
-    },
-    "currentUniqueKey" : 3,
-    "relatedDetectors" : [ ],
-    "revisionNumber" : 7
-  }
-}, {
-  "marshallId" : 29,
-  "marshallMemberOf" : [ 26 ],
-  "sf_chart" : "Response Size",
-  "sf_chartIndex" : 1528139299895,
-  "sf_description" : "5 largest average sizes of responses from upstream groups by Service/API compared with -24h overall average",
-  "sf_type" : "Chart",
-  "sf_uiModel" : {
-    "allPlots" : [ {
-      "_originalLabel" : "A",
-      "configuration" : {
-        "aliases" : { },
-        "colorOverride" : null,
-        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
-        "maxExtrapolations" : -1,
-        "prefix" : "",
-        "rollupPolicy" : null,
-        "suffix" : "",
-        "unitType" : "Byte",
-        "visualization" : null
-      },
-      "dataManipulations" : [ {
-        "direction" : {
-          "options" : {
-            "aggregateGroupBy" : [ {
-              "value" : "service_name"
-            } ],
-            "collapseGroups" : false,
-            "transformTimeRange" : null
-          },
-          "type" : "aggregation"
-        },
-        "fn" : {
-          "options" : { },
           "type" : "SUM"
         },
         "showMe" : false
       } ],
       "invisible" : true,
-      "name" : "counter.kong.responses.size - Sum by service_name",
+      "name" : "counter.kong.responses.size - Sum by host",
       "queryItems" : [ {
         "NOT" : false,
         "iconClass" : "icon-properties",
@@ -5722,54 +5632,6 @@
       "transient" : false,
       "type" : "plot",
       "uniqueKey" : 1,
-      "yAxisIndex" : 0
-    }, {
-      "_originalLabel" : "K",
-      "configuration" : {
-        "aliases" : { },
-        "colorOverride" : null,
-        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
-        "maxExtrapolations" : -1,
-        "prefix" : "",
-        "rollupPolicy" : null,
-        "suffix" : "",
-        "unitType" : "Byte",
-        "visualization" : null
-      },
-      "dataManipulations" : [ {
-        "direction" : {
-          "options" : {
-            "aggregateGroupBy" : [ {
-              "value" : "api_name"
-            } ],
-            "collapseGroups" : false,
-            "transformTimeRange" : null
-          },
-          "type" : "aggregation"
-        },
-        "fn" : {
-          "options" : { },
-          "type" : "SUM"
-        },
-        "showMe" : false
-      } ],
-      "invisible" : true,
-      "name" : "counter.kong.responses.size - Sum by api_name",
-      "queryItems" : [ {
-        "NOT" : false,
-        "iconClass" : "icon-properties",
-        "property" : "plugin",
-        "propertyValue" : "kong",
-        "type" : "property",
-        "value" : "kong"
-      } ],
-      "seriesData" : {
-        "metric" : "counter.kong.responses.size",
-        "regExStyle" : null
-      },
-      "transient" : false,
-      "type" : "plot",
-      "uniqueKey" : 11,
       "yAxisIndex" : 0
     }, {
       "_originalLabel" : "C",
@@ -5783,7 +5645,7 @@
         "direction" : {
           "options" : {
             "aggregateGroupBy" : [ {
-              "value" : "service_name"
+              "value" : "host"
             } ],
             "collapseGroups" : false,
             "transformTimeRange" : null
@@ -5798,7 +5660,7 @@
       } ],
       "invisible" : true,
       "metricDefinition" : { },
-      "name" : "counter.kong.responses.count - Sum by service_name",
+      "name" : "counter.kong.responses.count - Sum by host",
       "queryItems" : [ {
         "NOT" : false,
         "iconClass" : "icon-properties",
@@ -5816,284 +5678,35 @@
       "uniqueKey" : 3,
       "yAxisIndex" : 0
     }, {
-      "_originalLabel" : "L",
+      "_originalLabel" : "E",
       "configuration" : {
         "aliases" : { },
-        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
-        "maxExtrapolations" : -1,
-        "rollupPolicy" : null
-      },
-      "dataManipulations" : [ {
-        "direction" : {
-          "options" : {
-            "aggregateGroupBy" : [ {
-              "value" : "api_name"
-            } ],
-            "collapseGroups" : false,
-            "transformTimeRange" : null
-          },
-          "type" : "aggregation"
-        },
-        "fn" : {
-          "options" : { },
-          "type" : "SUM"
-        },
-        "showMe" : false
-      } ],
-      "invisible" : true,
-      "metricDefinition" : { },
-      "name" : "counter.kong.responses.count - Sum by api_name",
-      "queryItems" : [ {
-        "NOT" : false,
-        "iconClass" : "icon-properties",
-        "property" : "plugin",
-        "propertyValue" : "kong",
-        "type" : "property",
-        "value" : "kong"
-      } ],
-      "seriesData" : {
-        "metric" : "counter.kong.responses.count",
-        "regExStyle" : null
-      },
-      "transient" : false,
-      "type" : "plot",
-      "uniqueKey" : 12,
-      "yAxisIndex" : 0
-    }, {
-      "_originalLabel" : "M",
-      "configuration" : {
-        "aliases" : { },
-        "colorOverride" : null,
+        "colorOverride" : "#6ca2b7",
         "extrapolationPolicy" : "NULL_EXTRAPOLATION",
         "maxExtrapolations" : -1,
         "prefix" : "",
         "suffix" : "",
         "unitType" : "Byte"
       },
-      "dataManipulations" : [ {
-        "direction" : {
-          "options" : {
-            "aggregateGroupBy" : [ ],
-            "collapseGroups" : false,
-            "transformTimeRange" : null
-          },
-          "type" : "aggregation"
-        },
-        "fn" : {
-          "options" : {
-            "count" : 5
-          },
-          "type" : "TOPN"
-        },
-        "showMe" : false
-      } ],
+      "dataManipulations" : [ ],
       "expressionText" : "A/C",
       "invisible" : false,
       "metricDefinition" : { },
-      "name" : "response size (service)",
+      "name" : "response size",
       "queryItems" : [ ],
       "seriesData" : {
         "metric" : null
       },
       "transient" : false,
       "type" : "ratio",
-      "uniqueKey" : 13,
+      "uniqueKey" : 5,
       "valid" : true,
       "yAxisIndex" : 0
     }, {
-      "_originalLabel" : "O",
+      "_originalLabel" : "J",
       "configuration" : {
         "aliases" : { },
-        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
-        "maxExtrapolations" : -1,
-        "prefix" : "",
-        "suffix" : "",
-        "unitType" : "Byte"
-      },
-      "dataManipulations" : [ {
-        "direction" : {
-          "options" : {
-            "aggregateGroupBy" : [ ],
-            "collapseGroups" : false,
-            "transformTimeRange" : null
-          },
-          "type" : "aggregation"
-        },
-        "fn" : {
-          "options" : {
-            "count" : 5
-          },
-          "type" : "TOPN"
-        },
-        "showMe" : false
-      } ],
-      "expressionText" : "K/L",
-      "invisible" : false,
-      "metricDefinition" : { },
-      "name" : "response size (api)",
-      "queryItems" : [ ],
-      "seriesData" : {
-        "metric" : null
-      },
-      "transient" : false,
-      "type" : "ratio",
-      "uniqueKey" : 15,
-      "valid" : true,
-      "yAxisIndex" : 0
-    }, {
-      "_originalLabel" : "P",
-      "configuration" : {
-        "aliases" : { },
-        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
-        "maxExtrapolations" : -1
-      },
-      "dataManipulations" : [ {
-        "direction" : {
-          "options" : {
-            "aggregateGroupBy" : [ ],
-            "collapseGroups" : false,
-            "transformTimeRange" : null
-          },
-          "type" : "aggregation"
-        },
-        "fn" : {
-          "options" : { },
-          "type" : "SUM"
-        },
-        "showMe" : false
-      } ],
-      "expressionText" : "A",
-      "invisible" : true,
-      "metricDefinition" : { },
-      "name" : "A - Sum",
-      "queryItems" : [ ],
-      "seriesData" : {
-        "metric" : null
-      },
-      "transient" : false,
-      "type" : "ratio",
-      "uniqueKey" : 16,
-      "valid" : true,
-      "yAxisIndex" : 0
-    }, {
-      "_originalLabel" : "Q",
-      "configuration" : {
-        "aliases" : { },
-        "colorOverride" : null,
-        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
-        "maxExtrapolations" : -1,
-        "prefix" : "",
-        "suffix" : "",
-        "unitType" : "Byte",
-        "visualization" : null
-      },
-      "dataManipulations" : [ {
-        "direction" : {
-          "options" : {
-            "aggregateGroupBy" : [ ],
-            "collapseGroups" : false,
-            "transformTimeRange" : null
-          },
-          "type" : "aggregation"
-        },
-        "fn" : {
-          "options" : { },
-          "type" : "SUM"
-        },
-        "showMe" : false
-      } ],
-      "expressionText" : "C",
-      "invisible" : true,
-      "metricDefinition" : { },
-      "name" : "C - Sum",
-      "queryItems" : [ ],
-      "seriesData" : {
-        "metric" : null
-      },
-      "transient" : false,
-      "type" : "ratio",
-      "uniqueKey" : 17,
-      "valid" : true,
-      "yAxisIndex" : 0
-    }, {
-      "_originalLabel" : "R",
-      "configuration" : {
-        "aliases" : { },
-        "colorOverride" : null,
-        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
-        "maxExtrapolations" : -1,
-        "prefix" : "",
-        "suffix" : "",
-        "unitType" : "Byte"
-      },
-      "dataManipulations" : [ {
-        "direction" : {
-          "options" : {
-            "aggregateGroupBy" : [ ],
-            "collapseGroups" : false,
-            "transformTimeRange" : null
-          },
-          "type" : "aggregation"
-        },
-        "fn" : {
-          "options" : { },
-          "type" : "SUM"
-        },
-        "showMe" : false
-      } ],
-      "expressionText" : "K",
-      "invisible" : true,
-      "metricDefinition" : { },
-      "name" : "",
-      "queryItems" : [ ],
-      "seriesData" : {
-        "metric" : null
-      },
-      "transient" : false,
-      "type" : "ratio",
-      "uniqueKey" : 18,
-      "valid" : true,
-      "yAxisIndex" : 0
-    }, {
-      "_originalLabel" : "S",
-      "configuration" : {
-        "aliases" : { },
-        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
-        "maxExtrapolations" : -1
-      },
-      "dataManipulations" : [ {
-        "direction" : {
-          "options" : {
-            "aggregateGroupBy" : [ ],
-            "collapseGroups" : false,
-            "transformTimeRange" : null
-          },
-          "type" : "aggregation"
-        },
-        "fn" : {
-          "options" : { },
-          "type" : "SUM"
-        },
-        "showMe" : false
-      } ],
-      "expressionText" : "L",
-      "invisible" : true,
-      "metricDefinition" : { },
-      "name" : "L - Sum",
-      "queryItems" : [ ],
-      "seriesData" : {
-        "metric" : null
-      },
-      "transient" : false,
-      "type" : "ratio",
-      "uniqueKey" : 19,
-      "valid" : true,
-      "yAxisIndex" : 0
-    }, {
-      "_originalLabel" : "V",
-      "configuration" : {
-        "aliases" : { },
-        "colorOverride" : null,
+        "colorOverride" : "#b04600",
         "extrapolationPolicy" : "NULL_EXTRAPOLATION",
         "maxExtrapolations" : -1,
         "prefix" : "",
@@ -6118,7 +5731,7 @@
         },
         "showMe" : false
       } ],
-      "expressionText" : "(P+R)/(Q+S)",
+      "expressionText" : "E",
       "invisible" : false,
       "metricDefinition" : { },
       "name" : "response size (historic)",
@@ -6128,7 +5741,7 @@
       },
       "transient" : false,
       "type" : "ratio",
-      "uniqueKey" : 22,
+      "uniqueKey" : 10,
       "valid" : true,
       "yAxisIndex" : 1
     }, {
@@ -6145,34 +5758,20 @@
       "seriesData" : { },
       "transient" : true,
       "type" : "plot",
-      "uniqueKey" : 23,
+      "uniqueKey" : 11,
       "yAxisIndex" : 0
     } ],
-    "chartMode" : "list",
-    "chartType" : "line",
+    "chartMode" : "graph",
+    "chartType" : "area",
     "chartconfig" : {
       "absoluteEnd" : null,
       "absoluteStart" : null,
-      "colorByMetric" : false,
-      "colorByValue" : false,
-      "colorByValueScale" : [ ],
-      "groupBy" : [ ],
-      "heatmapAutoGradients" : 5,
-      "heatmapColorRange" : { },
-      "heatmapSortBy" : {
-        "asc" : true,
-        "value" : { }
-      },
-      "heatmapUnitsPerRow" : 0,
-      "heatmapUseValueAsColor" : false,
-      "hideTimestamp" : false,
-      "histogramColor" : "#0077c2",
+      "histogramColor" : "#ea1849",
       "legendColumnConfiguration" : null,
       "range" : -900000,
       "rangeEnd" : null,
-      "secondaryVisualization" : "SPARKLINE",
-      "sortPreference" : "-value",
-      "stackedChart" : false,
+      "secondaryVisualization" : "NONE",
+      "sortPreference" : "",
       "useKMG2" : false,
       "yAxisConfigurations" : [ {
         "id" : "yAxis0",
@@ -6197,343 +5796,15 @@
         }
       } ]
     },
-    "currentUniqueKey" : 24,
-    "relatedDetectors" : [ ],
-    "revisionNumber" : 33,
-    "uiHelperValue" : "##CHARTID##_33"
-  }
-}, {
-  "marshallId" : 30,
-  "marshallMemberOf" : [ 26 ],
-  "sf_chart" : "Responses by Status Code",
-  "sf_chartIndex" : 1528136271804,
-  "sf_description" : "Number of responses per interval by status code group",
-  "sf_type" : "Chart",
-  "sf_uiModel" : {
-    "allPlots" : [ {
-      "_originalLabel" : "E",
-      "configuration" : {
-        "aliases" : { },
-        "colorOverride" : "#999999",
-        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
-        "maxExtrapolations" : -1,
-        "rollupPolicy" : null,
-        "suffix" : "responses",
-        "unitType" : null
-      },
-      "dataManipulations" : [ {
-        "direction" : {
-          "options" : {
-            "aggregateGroupBy" : [ ],
-            "collapseGroups" : false,
-            "transformTimeRange" : null
-          },
-          "type" : "aggregation"
-        },
-        "fn" : {
-          "options" : { },
-          "type" : "SUM"
-        },
-        "showMe" : false
-      } ],
-      "invisible" : false,
-      "metricDefinition" : { },
-      "name" : "1xx",
-      "queryItems" : [ {
-        "NOT" : false,
-        "iconClass" : "icon-properties",
-        "isSynthetic" : true,
-        "property" : "plugin",
-        "propertyValue" : "kong",
-        "type" : "property",
-        "value" : "kong"
-      }, {
-        "NOT" : false,
-        "iconClass" : "icon-properties",
-        "property" : "status_code",
-        "propertyValue" : "1*",
-        "type" : "property",
-        "value" : "1*"
-      } ],
-      "seriesData" : {
-        "metric" : "counter.kong.responses.count",
-        "regExStyle" : null
-      },
-      "transient" : false,
-      "type" : "plot",
-      "uniqueKey" : 5,
-      "yAxisIndex" : 0
-    }, {
-      "_originalLabel" : "A",
-      "configuration" : {
-        "aliases" : { },
-        "colorOverride" : "#00b9ff",
-        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
-        "maxExtrapolations" : -1,
-        "rollupPolicy" : "DELTA_ROLLUP",
-        "suffix" : "responses",
-        "unitType" : null
-      },
-      "dataManipulations" : [ {
-        "direction" : {
-          "options" : {
-            "aggregateGroupBy" : [ ],
-            "collapseGroups" : false,
-            "transformTimeRange" : null
-          },
-          "type" : "aggregation"
-        },
-        "fn" : {
-          "options" : { },
-          "type" : "SUM"
-        },
-        "showMe" : false
-      } ],
-      "invisible" : false,
-      "name" : "2xx",
-      "queryItems" : [ {
-        "NOT" : false,
-        "iconClass" : "icon-properties",
-        "property" : "plugin",
-        "propertyValue" : "kong",
-        "type" : "property",
-        "value" : "kong"
-      }, {
-        "NOT" : false,
-        "iconClass" : "icon-properties",
-        "property" : "status_code",
-        "propertyValue" : "2*",
-        "type" : "property",
-        "value" : "2*"
-      } ],
-      "seriesData" : {
-        "metric" : "counter.kong.responses.count"
-      },
-      "transient" : false,
-      "type" : "plot",
-      "uniqueKey" : 1,
-      "yAxisIndex" : 0
-    }, {
-      "_originalLabel" : "C",
-      "configuration" : {
-        "aliases" : { },
-        "colorOverride" : "#e5b312",
-        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
-        "maxExtrapolations" : -1,
-        "rollupPolicy" : "DELTA_ROLLUP",
-        "suffix" : "responses",
-        "unitType" : null
-      },
-      "dataManipulations" : [ {
-        "direction" : {
-          "options" : {
-            "aggregateGroupBy" : [ ],
-            "collapseGroups" : false,
-            "transformTimeRange" : null
-          },
-          "type" : "aggregation"
-        },
-        "fn" : {
-          "options" : { },
-          "type" : "SUM"
-        },
-        "showMe" : false
-      } ],
-      "invisible" : false,
-      "metricDefinition" : { },
-      "name" : "3xx",
-      "queryItems" : [ {
-        "NOT" : false,
-        "iconClass" : "icon-properties",
-        "property" : "plugin",
-        "propertyValue" : "kong",
-        "type" : "property",
-        "value" : "kong"
-      }, {
-        "NOT" : false,
-        "iconClass" : "icon-properties",
-        "property" : "status_code",
-        "propertyValue" : "3*",
-        "type" : "property",
-        "value" : "3*"
-      } ],
-      "seriesData" : {
-        "metric" : "counter.kong.responses.count",
-        "regExStyle" : null
-      },
-      "transient" : false,
-      "type" : "plot",
-      "uniqueKey" : 3,
-      "yAxisIndex" : 0
-    }, {
-      "_originalLabel" : "B",
-      "configuration" : {
-        "aliases" : { },
-        "colorOverride" : "#b04600",
-        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
-        "maxExtrapolations" : -1,
-        "rollupPolicy" : "DELTA_ROLLUP",
-        "suffix" : "responses",
-        "unitType" : null
-      },
-      "dataManipulations" : [ {
-        "direction" : {
-          "options" : {
-            "aggregateGroupBy" : [ ],
-            "collapseGroups" : false,
-            "transformTimeRange" : null
-          },
-          "type" : "aggregation"
-        },
-        "fn" : {
-          "options" : { },
-          "type" : "SUM"
-        },
-        "showMe" : false
-      } ],
-      "invisible" : false,
-      "metricDefinition" : { },
-      "name" : "4xx",
-      "queryItems" : [ {
-        "NOT" : false,
-        "iconClass" : "icon-properties",
-        "property" : "plugin",
-        "propertyValue" : "kong",
-        "type" : "property",
-        "value" : "kong"
-      }, {
-        "NOT" : false,
-        "iconClass" : "icon-properties",
-        "property" : "status_code",
-        "propertyValue" : "4*",
-        "type" : "property",
-        "value" : "4*"
-      } ],
-      "seriesData" : {
-        "metric" : "counter.kong.responses.count",
-        "regExStyle" : null
-      },
-      "transient" : false,
-      "type" : "plot",
-      "uniqueKey" : 2,
-      "yAxisIndex" : 0
-    }, {
-      "_originalLabel" : "D",
-      "configuration" : {
-        "aliases" : { },
-        "colorOverride" : "#e9008a",
-        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
-        "maxExtrapolations" : -1,
-        "rollupPolicy" : "DELTA_ROLLUP",
-        "suffix" : "responses",
-        "unitType" : null
-      },
-      "dataManipulations" : [ {
-        "direction" : {
-          "options" : {
-            "aggregateGroupBy" : [ ],
-            "collapseGroups" : false,
-            "transformTimeRange" : null
-          },
-          "type" : "aggregation"
-        },
-        "fn" : {
-          "options" : { },
-          "type" : "SUM"
-        },
-        "showMe" : false
-      } ],
-      "invisible" : false,
-      "metricDefinition" : { },
-      "name" : "5xx",
-      "queryItems" : [ {
-        "NOT" : false,
-        "iconClass" : "icon-properties",
-        "property" : "plugin",
-        "propertyValue" : "kong",
-        "type" : "property",
-        "value" : "kong"
-      }, {
-        "NOT" : false,
-        "iconClass" : "icon-properties",
-        "property" : "status_code",
-        "propertyValue" : "5*",
-        "type" : "property",
-        "value" : "5*"
-      } ],
-      "seriesData" : {
-        "metric" : "counter.kong.responses.count",
-        "regExStyle" : null
-      },
-      "transient" : false,
-      "type" : "plot",
-      "uniqueKey" : 4,
-      "yAxisIndex" : 0
-    }, {
-      "configuration" : {
-        "aliases" : { },
-        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
-        "maxExtrapolations" : -1
-      },
-      "dataManipulations" : [ ],
-      "invisible" : false,
-      "metricDefinition" : { },
-      "name" : "New Plot",
-      "queryItems" : [ ],
-      "seriesData" : { },
-      "transient" : true,
-      "type" : "plot",
-      "uniqueKey" : 11,
-      "yAxisIndex" : 0
-    } ],
-    "chartMode" : "graph",
-    "chartType" : "area",
-    "chartconfig" : {
-      "absoluteEnd" : null,
-      "absoluteStart" : null,
-      "colorByMetric" : false,
-      "dimensionInLegend" : "sf_metric",
-      "groupBy" : [ ],
-      "heatmapAutoGradients" : 5,
-      "heatmapColorRange" : { },
-      "heatmapSortBy" : {
-        "asc" : true,
-        "value" : { }
-      },
-      "heatmapUnitsPerRow" : 0,
-      "heatmapUseValueAsColor" : false,
-      "hideTimestamp" : false,
-      "histogramColor" : "#ea1849",
-      "legendColumnConfiguration" : null,
-      "range" : -900000,
-      "rangeEnd" : null,
-      "secondaryVisualization" : "NONE",
-      "showLegend" : true,
-      "sortPreference" : "",
-      "stackedChart" : true,
-      "useKMG2" : false,
-      "yAxisConfigurations" : [ {
-        "id" : "yAxis0",
-        "label" : "resp/intvl",
-        "max" : null,
-        "min" : null,
-        "name" : "yAxis0",
-        "plotlines" : {
-          "high" : null,
-          "low" : null
-        }
-      } ]
-    },
     "currentUniqueKey" : 12,
-    "relatedDetectors" : [ ],
-    "revisionNumber" : 23,
-    "uiHelperValue" : "##CHARTID##_23"
+    "revisionNumber" : 26,
+    "uiHelperValue" : "##CHARTID##_26"
   }
 }, {
-  "marshallId" : 31,
+  "marshallId" : 29,
   "marshallMemberOf" : [ 26 ],
   "sf_chart" : "Bytes In / Second",
-  "sf_chartIndex" : 1528311465641,
+  "sf_chartIndex" : 1528311013969,
   "sf_description" : "Service/API-fielded request transfer rate compared with -24h",
   "sf_type" : "Chart",
   "sf_uiModel" : {
@@ -6678,15 +5949,246 @@
     },
     "currentUniqueKey" : 4,
     "relatedDetectors" : [ ],
-    "revisionNumber" : 9,
-    "uiHelperValue" : "##CHARTID##_9"
+    "revisionNumber" : 7,
+    "uiHelperValue" : "##CHARTID##_7"
   }
 }, {
-  "marshallId" : 32,
+  "marshallId" : 30,
   "marshallMemberOf" : [ 26 ],
-  "sf_chart" : "Responses / Second",
-  "sf_chartIndex" : 1528219376990,
-  "sf_description" : "Rate of responses by Service/API",
+  "sf_chart" : "Kong Latency",
+  "sf_chartIndex" : 1528147046843,
+  "sf_description" : "Average Kong-induced latency for requests compared with -24h",
+  "sf_type" : "Chart",
+  "sf_uiModel" : {
+    "allPlots" : [ {
+      "_originalLabel" : "A",
+      "configuration" : {
+        "aliases" : { },
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
+        "maxExtrapolations" : -1,
+        "prefix" : "",
+        "rollupPolicy" : "LATEST_ROLLUP",
+        "suffix" : "",
+        "unitType" : "Millisecond"
+      },
+      "dataManipulations" : [ {
+        "direction" : {
+          "options" : {
+            "aggregateGroupBy" : [ {
+              "value" : "host"
+            } ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          },
+          "type" : "aggregation"
+        },
+        "fn" : {
+          "options" : { },
+          "type" : "SUM"
+        },
+        "showMe" : false
+      } ],
+      "invisible" : true,
+      "name" : "counter.kong.kong.latency - Sum by host",
+      "queryItems" : [ {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "plugin",
+        "propertyValue" : "kong",
+        "type" : "property",
+        "value" : "kong"
+      } ],
+      "seriesData" : {
+        "metric" : "counter.kong.kong.latency",
+        "regExStyle" : null
+      },
+      "transient" : false,
+      "type" : "plot",
+      "uniqueKey" : 1,
+      "yAxisIndex" : 0
+    }, {
+      "_originalLabel" : "D",
+      "configuration" : {
+        "aliases" : { },
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
+        "maxExtrapolations" : -1,
+        "rollupPolicy" : "LATEST_ROLLUP"
+      },
+      "dataManipulations" : [ {
+        "direction" : {
+          "options" : {
+            "aggregateGroupBy" : [ {
+              "value" : "host"
+            } ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          },
+          "type" : "aggregation"
+        },
+        "fn" : {
+          "options" : { },
+          "type" : "SUM"
+        },
+        "showMe" : false
+      } ],
+      "invisible" : true,
+      "metricDefinition" : { },
+      "name" : "counter.kong.responses.count - Sum by host",
+      "queryItems" : [ {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "plugin",
+        "propertyValue" : "kong",
+        "type" : "property",
+        "value" : "kong"
+      } ],
+      "seriesData" : {
+        "metric" : "counter.kong.responses.count",
+        "regExStyle" : null
+      },
+      "transient" : false,
+      "type" : "plot",
+      "uniqueKey" : 4,
+      "yAxisIndex" : 0
+    }, {
+      "_originalLabel" : "E",
+      "configuration" : {
+        "aliases" : { },
+        "colorOverride" : "#ab99bc",
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
+        "maxExtrapolations" : -1,
+        "prefix" : "",
+        "suffix" : "",
+        "unitType" : "Millisecond"
+      },
+      "dataManipulations" : [ ],
+      "expressionText" : "A / D",
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "latency",
+      "queryItems" : [ ],
+      "seriesData" : {
+        "metric" : null
+      },
+      "transient" : false,
+      "type" : "ratio",
+      "uniqueKey" : 5,
+      "valid" : true,
+      "yAxisIndex" : 0
+    }, {
+      "_originalLabel" : "I",
+      "configuration" : {
+        "aliases" : { },
+        "colorOverride" : "#b04600",
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
+        "maxExtrapolations" : -1,
+        "prefix" : "",
+        "suffix" : "",
+        "unitType" : "Millisecond",
+        "visualization" : "line"
+      },
+      "dataManipulations" : [ {
+        "direction" : {
+          "options" : {
+            "aggregateGroupBy" : [ ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          },
+          "type" : "aggregation"
+        },
+        "fn" : {
+          "options" : {
+            "milliseconds" : 86400000
+          },
+          "type" : "TIMESHIFT"
+        },
+        "showMe" : false
+      } ],
+      "expressionText" : "E",
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "latency (historic)",
+      "queryItems" : [ ],
+      "seriesData" : {
+        "metric" : null
+      },
+      "transient" : false,
+      "type" : "ratio",
+      "uniqueKey" : 9,
+      "valid" : true,
+      "yAxisIndex" : 1
+    }, {
+      "configuration" : {
+        "aliases" : { },
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
+        "maxExtrapolations" : -1
+      },
+      "dataManipulations" : [ ],
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "New Plot",
+      "queryItems" : [ ],
+      "seriesData" : { },
+      "transient" : true,
+      "type" : "plot",
+      "uniqueKey" : 10,
+      "yAxisIndex" : 0
+    } ],
+    "chartMode" : "graph",
+    "chartType" : "area",
+    "chartconfig" : {
+      "absoluteEnd" : null,
+      "absoluteStart" : null,
+      "groupBy" : [ ],
+      "heatmapAutoGradients" : 5,
+      "heatmapColorRange" : { },
+      "heatmapSortBy" : {
+        "asc" : true,
+        "value" : { }
+      },
+      "heatmapUnitsPerRow" : 0,
+      "heatmapUseValueAsColor" : false,
+      "hideTimestamp" : false,
+      "histogramColor" : "#ea1849",
+      "range" : -900000,
+      "rangeEnd" : null,
+      "secondaryVisualization" : "NONE",
+      "sortPreference" : "",
+      "useKMG2" : false,
+      "yAxisConfigurations" : [ {
+        "id" : "yAxis0",
+        "label" : "latency/req",
+        "max" : null,
+        "min" : null,
+        "name" : "yAxis0",
+        "plotlines" : {
+          "high" : null,
+          "low" : null
+        }
+      }, {
+        "label" : "latency/req",
+        "max" : null,
+        "min" : null,
+        "plotlines" : {
+          "high" : null,
+          "low" : null
+        },
+        "title" : {
+          "text" : ""
+        }
+      } ]
+    },
+    "currentUniqueKey" : 11,
+    "relatedDetectors" : [ ],
+    "revisionNumber" : 22,
+    "uiHelperValue" : "##CHARTID##_22"
+  }
+}, {
+  "marshallId" : 31,
+  "marshallMemberOf" : [ 26 ],
+  "sf_chart" : "Requests by HTTP Method",
+  "sf_chartIndex" : 1528138165800,
+  "sf_description" : "Rate of Service/API-fielded requests by HTTP Method",
   "sf_type" : "Chart",
   "sf_uiModel" : {
     "allPlots" : [ {
@@ -6696,15 +6198,14 @@
         "colorOverride" : null,
         "extrapolationPolicy" : "NULL_EXTRAPOLATION",
         "maxExtrapolations" : -1,
-        "prefix" : "",
-        "suffix" : "responses",
+        "suffix" : "req/s",
         "unitType" : null
       },
       "dataManipulations" : [ {
         "direction" : {
           "options" : {
             "aggregateGroupBy" : [ {
-              "value" : "service_name"
+              "value" : "http_method"
             } ],
             "collapseGroups" : false,
             "transformTimeRange" : null
@@ -6718,13 +6219,12 @@
         "showMe" : false
       } ],
       "invisible" : false,
-      "name" : "upstream responses (service)",
+      "name" : "",
       "queryItems" : [ {
         "NOT" : false,
-        "iconClass" : "sf-icon-property",
+        "iconClass" : "icon-properties",
         "property" : "plugin",
         "propertyValue" : "kong",
-        "query" : "plugin:\"kong\"",
         "type" : "property",
         "value" : "kong"
       } ],
@@ -6736,22 +6236,75 @@
       "uniqueKey" : 1,
       "yAxisIndex" : 0
     }, {
-      "_originalLabel" : "B",
       "configuration" : {
         "aliases" : { },
-        "colorOverride" : null,
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
+        "maxExtrapolations" : -1
+      },
+      "dataManipulations" : [ ],
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "New Plot",
+      "queryItems" : [ ],
+      "seriesData" : { },
+      "transient" : true,
+      "type" : "plot",
+      "uniqueKey" : 18,
+      "yAxisIndex" : 0
+    } ],
+    "chartMode" : "list",
+    "chartType" : "line",
+    "chartconfig" : {
+      "absoluteEnd" : null,
+      "absoluteStart" : null,
+      "colorByMetric" : false,
+      "colorByValue" : false,
+      "colorByValueScale" : [ ],
+      "histogramColor" : "#ea1849",
+      "maxDecimalPlaces" : 4,
+      "range" : -900000,
+      "rangeEnd" : null,
+      "secondaryVisualization" : "SPARKLINE",
+      "sortPreference" : "+http_method",
+      "useKMG2" : false,
+      "yAxisConfigurations" : [ {
+        "id" : "yAxis0",
+        "max" : null,
+        "min" : null,
+        "name" : "yAxis0",
+        "plotlines" : {
+          "high" : null,
+          "low" : null
+        }
+      } ]
+    },
+    "currentUniqueKey" : 19,
+    "revisionNumber" : 18,
+    "uiHelperValue" : "##CHARTID##_18"
+  }
+}, {
+  "marshallId" : 32,
+  "marshallMemberOf" : [ 26 ],
+  "sf_chart" : "Responses by Status Code",
+  "sf_chartIndex" : 1528136271804,
+  "sf_description" : "Number of responses per interval by status code group",
+  "sf_type" : "Chart",
+  "sf_uiModel" : {
+    "allPlots" : [ {
+      "_originalLabel" : "E",
+      "configuration" : {
+        "aliases" : { },
+        "colorOverride" : "#999999",
         "extrapolationPolicy" : "NULL_EXTRAPOLATION",
         "maxExtrapolations" : -1,
-        "prefix" : "",
+        "rollupPolicy" : null,
         "suffix" : "responses",
         "unitType" : null
       },
       "dataManipulations" : [ {
         "direction" : {
           "options" : {
-            "aggregateGroupBy" : [ {
-              "value" : "api_name"
-            } ],
+            "aggregateGroupBy" : [ ],
             "collapseGroups" : false,
             "transformTimeRange" : null
           },
@@ -6764,23 +6317,388 @@
         "showMe" : false
       } ],
       "invisible" : false,
-      "name" : "upstream responses (api)",
+      "metricDefinition" : { },
+      "name" : "1xx",
       "queryItems" : [ {
         "NOT" : false,
-        "iconClass" : "sf-icon-property",
+        "iconClass" : "icon-properties",
+        "isSynthetic" : true,
         "property" : "plugin",
         "propertyValue" : "kong",
-        "query" : "plugin:\"kong\"",
         "type" : "property",
         "value" : "kong"
+      }, {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "status_code",
+        "propertyValue" : "1*",
+        "type" : "property",
+        "value" : "1*"
+      } ],
+      "seriesData" : {
+        "metric" : "counter.kong.responses.count",
+        "regExStyle" : null
+      },
+      "transient" : false,
+      "type" : "plot",
+      "uniqueKey" : 5,
+      "yAxisIndex" : 0
+    }, {
+      "_originalLabel" : "A",
+      "configuration" : {
+        "aliases" : { },
+        "colorOverride" : "#00b9ff",
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
+        "maxExtrapolations" : -1,
+        "rollupPolicy" : "DELTA_ROLLUP",
+        "suffix" : "responses",
+        "unitType" : null
+      },
+      "dataManipulations" : [ {
+        "direction" : {
+          "options" : {
+            "aggregateGroupBy" : [ ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          },
+          "type" : "aggregation"
+        },
+        "fn" : {
+          "options" : { },
+          "type" : "SUM"
+        },
+        "showMe" : false
+      } ],
+      "invisible" : false,
+      "name" : "2xx",
+      "queryItems" : [ {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "plugin",
+        "propertyValue" : "kong",
+        "type" : "property",
+        "value" : "kong"
+      }, {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "status_code",
+        "propertyValue" : "2*",
+        "type" : "property",
+        "value" : "2*"
       } ],
       "seriesData" : {
         "metric" : "counter.kong.responses.count"
       },
       "transient" : false,
       "type" : "plot",
+      "uniqueKey" : 1,
+      "yAxisIndex" : 0
+    }, {
+      "_originalLabel" : "C",
+      "configuration" : {
+        "aliases" : { },
+        "colorOverride" : "#e5b312",
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
+        "maxExtrapolations" : -1,
+        "rollupPolicy" : "DELTA_ROLLUP",
+        "suffix" : "responses",
+        "unitType" : null
+      },
+      "dataManipulations" : [ {
+        "direction" : {
+          "options" : {
+            "aggregateGroupBy" : [ ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          },
+          "type" : "aggregation"
+        },
+        "fn" : {
+          "options" : { },
+          "type" : "SUM"
+        },
+        "showMe" : false
+      } ],
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "3xx",
+      "queryItems" : [ {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "plugin",
+        "propertyValue" : "kong",
+        "type" : "property",
+        "value" : "kong"
+      }, {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "status_code",
+        "propertyValue" : "3*",
+        "type" : "property",
+        "value" : "3*"
+      } ],
+      "seriesData" : {
+        "metric" : "counter.kong.responses.count",
+        "regExStyle" : null
+      },
+      "transient" : false,
+      "type" : "plot",
+      "uniqueKey" : 3,
+      "yAxisIndex" : 0
+    }, {
+      "_originalLabel" : "B",
+      "configuration" : {
+        "aliases" : { },
+        "colorOverride" : "#b04600",
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
+        "maxExtrapolations" : -1,
+        "rollupPolicy" : "DELTA_ROLLUP",
+        "suffix" : "responses",
+        "unitType" : null
+      },
+      "dataManipulations" : [ {
+        "direction" : {
+          "options" : {
+            "aggregateGroupBy" : [ ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          },
+          "type" : "aggregation"
+        },
+        "fn" : {
+          "options" : { },
+          "type" : "SUM"
+        },
+        "showMe" : false
+      } ],
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "4xx",
+      "queryItems" : [ {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "plugin",
+        "propertyValue" : "kong",
+        "type" : "property",
+        "value" : "kong"
+      }, {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "status_code",
+        "propertyValue" : "4*",
+        "type" : "property",
+        "value" : "4*"
+      } ],
+      "seriesData" : {
+        "metric" : "counter.kong.responses.count",
+        "regExStyle" : null
+      },
+      "transient" : false,
+      "type" : "plot",
       "uniqueKey" : 2,
       "yAxisIndex" : 0
+    }, {
+      "_originalLabel" : "D",
+      "configuration" : {
+        "aliases" : { },
+        "colorOverride" : "#e9008a",
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
+        "maxExtrapolations" : -1,
+        "rollupPolicy" : "DELTA_ROLLUP",
+        "suffix" : "responses",
+        "unitType" : null
+      },
+      "dataManipulations" : [ {
+        "direction" : {
+          "options" : {
+            "aggregateGroupBy" : [ ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          },
+          "type" : "aggregation"
+        },
+        "fn" : {
+          "options" : { },
+          "type" : "SUM"
+        },
+        "showMe" : false
+      } ],
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "5xx",
+      "queryItems" : [ {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "plugin",
+        "propertyValue" : "kong",
+        "type" : "property",
+        "value" : "kong"
+      }, {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "status_code",
+        "propertyValue" : "5*",
+        "type" : "property",
+        "value" : "5*"
+      } ],
+      "seriesData" : {
+        "metric" : "counter.kong.responses.count",
+        "regExStyle" : null
+      },
+      "transient" : false,
+      "type" : "plot",
+      "uniqueKey" : 4,
+      "yAxisIndex" : 0
+    }, {
+      "configuration" : {
+        "aliases" : { },
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
+        "maxExtrapolations" : -1
+      },
+      "dataManipulations" : [ ],
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "New Plot",
+      "queryItems" : [ ],
+      "seriesData" : { },
+      "transient" : true,
+      "type" : "plot",
+      "uniqueKey" : 11,
+      "yAxisIndex" : 0
+    } ],
+    "chartMode" : "graph",
+    "chartType" : "area",
+    "chartconfig" : {
+      "absoluteEnd" : null,
+      "absoluteStart" : null,
+      "dimensionInLegend" : "sf_metric",
+      "groupBy" : [ ],
+      "heatmapAutoGradients" : 5,
+      "heatmapColorRange" : { },
+      "heatmapSortBy" : {
+        "asc" : true,
+        "value" : { }
+      },
+      "heatmapUnitsPerRow" : 0,
+      "heatmapUseValueAsColor" : false,
+      "hideTimestamp" : false,
+      "histogramColor" : "#ea1849",
+      "legendColumnConfiguration" : null,
+      "range" : -900000,
+      "rangeEnd" : null,
+      "secondaryVisualization" : "NONE",
+      "showLegend" : true,
+      "sortPreference" : "",
+      "stackedChart" : true,
+      "useKMG2" : false,
+      "yAxisConfigurations" : [ {
+        "id" : "yAxis0",
+        "label" : "resp/intvl",
+        "max" : null,
+        "min" : null,
+        "name" : "yAxis0",
+        "plotlines" : {
+          "high" : null,
+          "low" : null
+        }
+      } ]
+    },
+    "currentUniqueKey" : 12,
+    "revisionNumber" : 22,
+    "uiHelperValue" : "##CHARTID##_22"
+  }
+}, {
+  "marshallId" : 33,
+  "marshallMemberOf" : [ 26 ],
+  "sf_chart" : "Bytes Out / Second",
+  "sf_chartIndex" : 1528310523139,
+  "sf_description" : "Service/API response transfer rate compared with -24h",
+  "sf_type" : "Chart",
+  "sf_uiModel" : {
+    "allPlots" : [ {
+      "_originalLabel" : "A",
+      "configuration" : {
+        "aliases" : { },
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
+        "maxExtrapolations" : -1,
+        "prefix" : "",
+        "suffix" : "",
+        "unitType" : "Byte"
+      },
+      "dataManipulations" : [ {
+        "direction" : {
+          "options" : {
+            "aggregateGroupBy" : [ ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          },
+          "type" : "aggregation"
+        },
+        "fn" : {
+          "options" : { },
+          "type" : "SUM"
+        },
+        "showMe" : false
+      } ],
+      "invisible" : false,
+      "name" : "responses",
+      "queryItems" : [ {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "plugin",
+        "propertyValue" : "kong",
+        "type" : "property",
+        "value" : "kong"
+      } ],
+      "seriesData" : {
+        "metric" : "counter.kong.responses.size"
+      },
+      "transient" : false,
+      "type" : "plot",
+      "uniqueKey" : 1,
+      "yAxisIndex" : 0
+    }, {
+      "_originalLabel" : "B",
+      "configuration" : {
+        "aliases" : { },
+        "colorOverride" : "#b04600",
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
+        "maxExtrapolations" : -1,
+        "prefix" : "",
+        "suffix" : "",
+        "unitType" : "Byte",
+        "visualization" : "line"
+      },
+      "dataManipulations" : [ {
+        "direction" : {
+          "options" : {
+            "aggregateGroupBy" : [ ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          },
+          "type" : "aggregation"
+        },
+        "fn" : {
+          "options" : {
+            "milliseconds" : 86400000
+          },
+          "type" : "TIMESHIFT"
+        },
+        "showMe" : false
+      } ],
+      "expressionText" : "A",
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "responses (historic)",
+      "queryItems" : [ ],
+      "seriesData" : {
+        "metric" : null
+      },
+      "transient" : false,
+      "type" : "ratio",
+      "uniqueKey" : 2,
+      "valid" : true,
+      "yAxisIndex" : 1
     }, {
       "configuration" : {
         "aliases" : { },
@@ -6803,23 +6721,15 @@
     "chartconfig" : {
       "absoluteEnd" : null,
       "absoluteStart" : null,
-      "colorByMetric" : false,
-      "colorByValue" : false,
-      "colorByValueScale" : [ ],
-      "dimensionInLegend" : "api_name",
-      "hideTimestamp" : false,
       "histogramColor" : "#ea1849",
-      "maxDecimalPlaces" : 2,
-      "range" : -3600000,
-      "rangeEnd" : 0,
+      "range" : -900000,
+      "rangeEnd" : null,
       "secondaryVisualization" : "NONE",
-      "showLegend" : false,
       "sortPreference" : "",
-      "stackedChart" : true,
       "useKMG2" : false,
       "yAxisConfigurations" : [ {
         "id" : "yAxis0",
-        "label" : "resp/s",
+        "label" : "resp bytes/s",
         "max" : null,
         "min" : null,
         "name" : "yAxis0",
@@ -6827,18 +6737,28 @@
           "high" : null,
           "low" : null
         }
+      }, {
+        "label" : "resp bytes/s",
+        "max" : null,
+        "min" : null,
+        "plotlines" : {
+          "high" : null,
+          "low" : null
+        },
+        "title" : {
+          "text" : ""
+        }
       } ]
     },
     "currentUniqueKey" : 4,
-    "relatedDetectors" : [ ],
-    "revisionNumber" : 26,
-    "uiHelperValue" : "##CHARTID##_26"
+    "revisionNumber" : 9,
+    "uiHelperValue" : "##CHARTID##_9"
   }
 }, {
-  "marshallId" : 33,
+  "marshallId" : 34,
   "marshallMemberOf" : [ 26 ],
   "sf_chart" : "Request Latency",
-  "sf_chartIndex" : 1528729931437,
+  "sf_chartIndex" : 1528729536811,
   "sf_description" : "Average request processing time compared with -24h",
   "sf_type" : "Chart",
   "sf_uiModel" : {
@@ -7021,6 +6941,7 @@
     "chartconfig" : {
       "absoluteEnd" : null,
       "absoluteStart" : null,
+      "axisPrecision" : null,
       "colorByMetric" : false,
       "groupBy" : [ ],
       "heatmapAutoGradients" : 5,
@@ -7063,15 +6984,445 @@
     },
     "currentUniqueKey" : 11,
     "relatedDetectors" : [ ],
-    "revisionNumber" : 24,
-    "uiHelperValue" : "##CHARTID##_24"
+    "revisionNumber" : 27,
+    "uiHelperValue" : "##CHARTID##_27"
   }
 }, {
-  "marshallId" : 34,
+  "marshallId" : 35,
+  "marshallMemberOf" : [ 26 ],
+  "sf_chart" : "# Kong Servers",
+  "sf_chartIndex" : 1528220571437,
+  "sf_description" : "Number of Kong servers actively reporting",
+  "sf_type" : "Chart",
+  "sf_uiModel" : {
+    "allPlots" : [ {
+      "_originalLabel" : "A",
+      "configuration" : {
+        "aliases" : { },
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
+        "maxExtrapolations" : -1,
+        "rollupPolicy" : null
+      },
+      "dataManipulations" : [ {
+        "direction" : {
+          "options" : {
+            "aggregateGroupBy" : [ ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          },
+          "type" : "aggregation"
+        },
+        "fn" : {
+          "options" : { },
+          "type" : "COUNT"
+        },
+        "showMe" : false
+      } ],
+      "invisible" : false,
+      "name" : "servers",
+      "queryItems" : [ {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "plugin",
+        "propertyValue" : "kong",
+        "type" : "property",
+        "value" : "kong"
+      } ],
+      "seriesData" : {
+        "metric" : "counter.kong.requests.count",
+        "regExStyle" : null
+      },
+      "transient" : false,
+      "type" : "plot",
+      "uniqueKey" : 1,
+      "yAxisIndex" : 0
+    }, {
+      "configuration" : {
+        "aliases" : { },
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
+        "maxExtrapolations" : -1
+      },
+      "dataManipulations" : [ ],
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "New Plot",
+      "queryItems" : [ ],
+      "seriesData" : { },
+      "transient" : true,
+      "type" : "plot",
+      "uniqueKey" : 2,
+      "yAxisIndex" : 0
+    } ],
+    "chartMode" : "single",
+    "chartType" : "line",
+    "chartconfig" : {
+      "absoluteEnd" : null,
+      "absoluteStart" : null,
+      "colorByValueScale" : [ ],
+      "hideTimestamp" : false,
+      "histogramColor" : "#ea1849",
+      "range" : -900000,
+      "rangeEnd" : null,
+      "secondaryVisualization" : "NONE",
+      "sortPreference" : "",
+      "useKMG2" : false,
+      "yAxisConfigurations" : [ {
+        "id" : "yAxis0",
+        "max" : null,
+        "min" : null,
+        "name" : "yAxis0",
+        "plotlines" : {
+          "high" : null,
+          "low" : null
+        }
+      } ]
+    },
+    "currentUniqueKey" : 3,
+    "revisionNumber" : 2,
+    "uiHelperValue" : "##CHARTID##_2"
+  }
+}, {
+  "marshallId" : 36,
+  "marshallMemberOf" : [ 26 ],
+  "sf_chart" : "Database Reachable",
+  "sf_chartIndex" : 1528137157576,
+  "sf_description" : "Connection status as reported by kong.dao",
+  "sf_type" : "Chart",
+  "sf_uiModel" : {
+    "allPlots" : [ {
+      "_originalLabel" : "A",
+      "configuration" : {
+        "aliases" : { },
+        "extrapolationPolicy" : "LAST_VALUE_EXTRAPOLATION",
+        "maxExtrapolations" : -1,
+        "prefix" : "",
+        "suffix" : "",
+        "unitType" : null
+      },
+      "dataManipulations" : [ {
+        "direction" : {
+          "options" : {
+            "aggregateGroupBy" : [ {
+              "value" : "host"
+            } ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          },
+          "type" : "aggregation"
+        },
+        "fn" : {
+          "options" : { },
+          "type" : "COUNT"
+        },
+        "showMe" : false
+      } ],
+      "invisible" : false,
+      "name" : "is reachable",
+      "queryItems" : [ {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "plugin",
+        "propertyValue" : "kong",
+        "type" : "property",
+        "value" : "kong"
+      } ],
+      "seriesData" : {
+        "metric" : "gauge.kong.database.reachable"
+      },
+      "transient" : false,
+      "type" : "plot",
+      "uniqueKey" : 1,
+      "yAxisIndex" : 0
+    }, {
+      "configuration" : {
+        "aliases" : { },
+        "extrapolationPolicy" : "LAST_VALUE_EXTRAPOLATION",
+        "maxExtrapolations" : -1
+      },
+      "dataManipulations" : [ ],
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "New Plot",
+      "queryItems" : [ ],
+      "seriesData" : { },
+      "transient" : true,
+      "type" : "plot",
+      "uniqueKey" : 2,
+      "yAxisIndex" : 0
+    } ],
+    "chartMode" : "heatmap",
+    "chartType" : null,
+    "chartconfig" : {
+      "absoluteEnd" : null,
+      "absoluteStart" : null,
+      "colorByMetric" : false,
+      "colorByValue" : true,
+      "colorByValueScale" : [ {
+        "color" : "#6bd37e",
+        "gte" : 1
+      }, {
+        "color" : "#ea1849",
+        "lt" : 1
+      } ],
+      "groupBy" : [ ],
+      "heatmapAutoGradients" : 5,
+      "heatmapColorOverride" : "#05ce00",
+      "heatmapColorRange" : {
+        "max" : 1,
+        "min" : 0
+      },
+      "heatmapSortBy" : {
+        "asc" : true,
+        "value" : { }
+      },
+      "heatmapUnitsPerRow" : 0,
+      "heatmapUseValueAsColor" : false,
+      "hideTimestamp" : false,
+      "histogramColor" : "#ea1849",
+      "range" : -900000,
+      "rangeEnd" : null,
+      "secondaryVisualization" : "NONE",
+      "sortPreference" : "",
+      "useKMG2" : false,
+      "yAxisConfigurations" : [ {
+        "id" : "yAxis0",
+        "max" : null,
+        "min" : null,
+        "name" : "yAxis0",
+        "plotlines" : {
+          "high" : null,
+          "low" : null
+        }
+      } ]
+    },
+    "currentUniqueKey" : 3,
+    "revisionNumber" : 7,
+    "uiHelperValue" : "##CHARTID##_7"
+  }
+}, {
+  "marshallId" : 37,
+  "marshallMemberOf" : [ 26 ],
+  "sf_chart" : "Connections by State",
+  "sf_chartIndex" : 1528135823509,
+  "sf_description" : "Number of connections in each state",
+  "sf_type" : "Chart",
+  "sf_uiModel" : {
+    "allPlots" : [ {
+      "_originalLabel" : "A",
+      "configuration" : {
+        "aliases" : { },
+        "colorOverride" : "#007c1d",
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
+        "maxExtrapolations" : -1,
+        "rollupPolicy" : "SUM_ROLLUP"
+      },
+      "dataManipulations" : [ {
+        "direction" : {
+          "options" : {
+            "aggregateGroupBy" : [ ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          },
+          "type" : "aggregation"
+        },
+        "fn" : {
+          "options" : { },
+          "type" : "SUM"
+        },
+        "showMe" : false
+      } ],
+      "invisible" : false,
+      "name" : "active",
+      "queryItems" : [ {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "plugin",
+        "propertyValue" : "kong",
+        "type" : "property",
+        "value" : "kong"
+      } ],
+      "seriesData" : {
+        "metric" : "gauge.kong.connections.active"
+      },
+      "transient" : false,
+      "type" : "plot",
+      "uniqueKey" : 1,
+      "yAxisIndex" : 0
+    }, {
+      "_originalLabel" : "B",
+      "configuration" : {
+        "aliases" : { },
+        "colorOverride" : "#ff8dd1",
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
+        "maxExtrapolations" : -1,
+        "rollupPolicy" : "SUM_ROLLUP"
+      },
+      "dataManipulations" : [ {
+        "direction" : {
+          "options" : {
+            "aggregateGroupBy" : [ ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          },
+          "type" : "aggregation"
+        },
+        "fn" : {
+          "options" : { },
+          "type" : "SUM"
+        },
+        "showMe" : false
+      } ],
+      "invisible" : false,
+      "name" : "reading",
+      "queryItems" : [ {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "plugin",
+        "propertyValue" : "kong",
+        "type" : "property",
+        "value" : "kong"
+      } ],
+      "seriesData" : {
+        "metric" : "gauge.kong.connections.reading"
+      },
+      "transient" : false,
+      "type" : "plot",
+      "uniqueKey" : 2,
+      "yAxisIndex" : 0
+    }, {
+      "_originalLabel" : "C",
+      "configuration" : {
+        "aliases" : { },
+        "colorOverride" : "#e9008a",
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
+        "maxExtrapolations" : -1,
+        "rollupPolicy" : "SUM_ROLLUP"
+      },
+      "dataManipulations" : [ {
+        "direction" : {
+          "options" : {
+            "aggregateGroupBy" : [ ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          },
+          "type" : "aggregation"
+        },
+        "fn" : {
+          "options" : { },
+          "type" : "SUM"
+        },
+        "showMe" : false
+      } ],
+      "invisible" : false,
+      "name" : "waiting",
+      "queryItems" : [ {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "plugin",
+        "propertyValue" : "kong",
+        "type" : "property",
+        "value" : "kong"
+      } ],
+      "seriesData" : {
+        "metric" : "gauge.kong.connections.waiting"
+      },
+      "transient" : false,
+      "type" : "plot",
+      "uniqueKey" : 3,
+      "yAxisIndex" : 0
+    }, {
+      "_originalLabel" : "D",
+      "configuration" : {
+        "aliases" : { },
+        "colorOverride" : "#00b9ff",
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
+        "maxExtrapolations" : -1,
+        "rollupPolicy" : "SUM_ROLLUP"
+      },
+      "dataManipulations" : [ {
+        "direction" : {
+          "options" : {
+            "aggregateGroupBy" : [ ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          },
+          "type" : "aggregation"
+        },
+        "fn" : {
+          "options" : { },
+          "type" : "SUM"
+        },
+        "showMe" : false
+      } ],
+      "invisible" : false,
+      "name" : "writing",
+      "queryItems" : [ {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "plugin",
+        "propertyValue" : "kong",
+        "type" : "property",
+        "value" : "kong"
+      } ],
+      "seriesData" : {
+        "metric" : "gauge.kong.connections.writing"
+      },
+      "transient" : false,
+      "type" : "plot",
+      "uniqueKey" : 4,
+      "yAxisIndex" : 0
+    }, {
+      "configuration" : {
+        "aliases" : { },
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
+        "maxExtrapolations" : -1
+      },
+      "dataManipulations" : [ ],
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "New Plot",
+      "queryItems" : [ ],
+      "seriesData" : { },
+      "transient" : true,
+      "type" : "plot",
+      "uniqueKey" : 10,
+      "yAxisIndex" : 0
+    } ],
+    "chartMode" : "list",
+    "chartType" : "line",
+    "chartconfig" : {
+      "absoluteEnd" : null,
+      "absoluteStart" : null,
+      "colorByMetric" : false,
+      "colorByValue" : false,
+      "colorByValueScale" : [ ],
+      "histogramColor" : "#ea1849",
+      "range" : -900000,
+      "rangeEnd" : null,
+      "secondaryVisualization" : "SPARKLINE",
+      "sortPreference" : "",
+      "useKMG2" : false,
+      "yAxisConfigurations" : [ {
+        "id" : "yAxis0",
+        "max" : null,
+        "min" : null,
+        "name" : "yAxis0",
+        "plotlines" : {
+          "high" : null,
+          "low" : null
+        }
+      } ]
+    },
+    "currentUniqueKey" : 11,
+    "revisionNumber" : 11,
+    "uiHelperValue" : "##CHARTID##_11"
+  }
+}, {
+  "marshallId" : 38,
   "marshallMemberOf" : [ 26 ],
   "sf_chart" : "Responses / Second",
   "sf_chartIndex" : 1528134810674,
-  "sf_description" : "Rate of responses from Kong",
+  "sf_description" : "Rate of upstream responses",
   "sf_type" : "Chart",
   "sf_uiModel" : {
     "allPlots" : [ {
@@ -7146,8 +7497,8 @@
       "hideTimestamp" : false,
       "histogramColor" : "#ea1849",
       "maxDecimalPlaces" : 2,
-      "range" : -1800000,
-      "rangeEnd" : 0,
+      "range" : -900000,
+      "rangeEnd" : null,
       "secondaryVisualization" : "NONE",
       "sortPreference" : "",
       "useKMG2" : false,
@@ -7163,13 +7514,835 @@
       } ]
     },
     "currentUniqueKey" : 3,
-    "relatedDetectors" : [ ],
-    "revisionNumber" : 15,
-    "uiHelperValue" : "##CHARTID##_15"
+    "revisionNumber" : 14,
+    "uiHelperValue" : "##CHARTID##_14"
   }
 }, {
-  "marshallId" : 35,
+  "marshallId" : 39,
   "marshallMemberOf" : [ 26 ],
+  "sf_chart" : "Requests / Second",
+  "sf_chartIndex" : 1528137043591,
+  "sf_description" : "Rate of total requests made to Kong",
+  "sf_type" : "Chart",
+  "sf_uiModel" : {
+    "allPlots" : [ {
+      "_originalLabel" : "A",
+      "configuration" : {
+        "aliases" : { },
+        "colorOverride" : null,
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
+        "maxExtrapolations" : -1,
+        "suffix" : "requests",
+        "unitType" : null
+      },
+      "dataManipulations" : [ {
+        "direction" : {
+          "options" : {
+            "aggregateGroupBy" : [ {
+              "value" : "host"
+            } ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          },
+          "type" : "aggregation"
+        },
+        "fn" : {
+          "options" : { },
+          "type" : "SUM"
+        },
+        "showMe" : false
+      } ],
+      "invisible" : false,
+      "name" : "total requests",
+      "queryItems" : [ {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "plugin",
+        "propertyValue" : "kong",
+        "type" : "property",
+        "value" : "kong"
+      } ],
+      "seriesData" : {
+        "metric" : "counter.kong.requests.count"
+      },
+      "transient" : false,
+      "type" : "plot",
+      "uniqueKey" : 1,
+      "yAxisIndex" : 0
+    }, {
+      "configuration" : {
+        "aliases" : { },
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
+        "maxExtrapolations" : -1
+      },
+      "dataManipulations" : [ ],
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "New Plot",
+      "queryItems" : [ ],
+      "seriesData" : { },
+      "transient" : true,
+      "type" : "plot",
+      "uniqueKey" : 3,
+      "yAxisIndex" : 0
+    } ],
+    "chartMode" : "graph",
+    "chartType" : "area",
+    "chartconfig" : {
+      "absoluteEnd" : null,
+      "absoluteStart" : null,
+      "histogramColor" : "#ea1849",
+      "range" : -900000,
+      "rangeEnd" : null,
+      "secondaryVisualization" : "NONE",
+      "sortPreference" : "",
+      "stackedChart" : true,
+      "useKMG2" : false,
+      "yAxisConfigurations" : [ {
+        "id" : "yAxis0",
+        "label" : "req/s",
+        "max" : null,
+        "min" : null,
+        "name" : "yAxis0",
+        "plotlines" : {
+          "high" : null,
+          "low" : null
+        }
+      } ]
+    },
+    "currentUniqueKey" : 4,
+    "revisionNumber" : 14,
+    "uiHelperValue" : "##CHARTID##_14"
+  }
+}, {
+  "marshallId" : 40,
+  "marshallMemberOf" : [ 26 ],
+  "sf_chart" : "Request Size",
+  "sf_chartIndex" : 1528146664212,
+  "sf_description" : "Average size of Service/API-fielded client request compared with -24h",
+  "sf_type" : "Chart",
+  "sf_uiModel" : {
+    "allPlots" : [ {
+      "_originalLabel" : "A",
+      "configuration" : {
+        "aliases" : { },
+        "colorOverride" : null,
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
+        "maxExtrapolations" : -1,
+        "prefix" : "",
+        "rollupPolicy" : null,
+        "suffix" : "",
+        "unitType" : "Byte",
+        "visualization" : null
+      },
+      "dataManipulations" : [ {
+        "direction" : {
+          "options" : {
+            "aggregateGroupBy" : [ {
+              "value" : "host"
+            } ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          },
+          "type" : "aggregation"
+        },
+        "fn" : {
+          "options" : { },
+          "type" : "SUM"
+        },
+        "showMe" : false
+      } ],
+      "invisible" : true,
+      "name" : "counter.kong.requests.size - Sum by host",
+      "queryItems" : [ {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "plugin",
+        "propertyValue" : "kong",
+        "type" : "property",
+        "value" : "kong"
+      } ],
+      "seriesData" : {
+        "metric" : "counter.kong.requests.size",
+        "regExStyle" : null
+      },
+      "transient" : false,
+      "type" : "plot",
+      "uniqueKey" : 1,
+      "yAxisIndex" : 0
+    }, {
+      "_originalLabel" : "B",
+      "configuration" : {
+        "aliases" : { },
+        "colorOverride" : null,
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
+        "maxExtrapolations" : -1,
+        "prefix" : "",
+        "rollupPolicy" : null,
+        "suffix" : "",
+        "unitType" : "Byte"
+      },
+      "dataManipulations" : [ {
+        "direction" : {
+          "options" : {
+            "aggregateGroupBy" : [ {
+              "value" : "host"
+            } ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          },
+          "type" : "aggregation"
+        },
+        "fn" : {
+          "options" : { },
+          "type" : "SUM"
+        },
+        "showMe" : false
+      } ],
+      "invisible" : true,
+      "name" : "counter.kong.responses.count - Sum by host",
+      "queryItems" : [ {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "plugin",
+        "propertyValue" : "kong",
+        "type" : "property",
+        "value" : "kong"
+      } ],
+      "seriesData" : {
+        "metric" : "counter.kong.responses.count",
+        "regExStyle" : null
+      },
+      "transient" : false,
+      "type" : "plot",
+      "uniqueKey" : 2,
+      "yAxisIndex" : 0
+    }, {
+      "_originalLabel" : "E",
+      "configuration" : {
+        "aliases" : { },
+        "colorOverride" : "#0dba8f",
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
+        "maxExtrapolations" : -1,
+        "prefix" : "",
+        "suffix" : "",
+        "unitType" : "Byte"
+      },
+      "dataManipulations" : [ ],
+      "expressionText" : "A/B",
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "request size",
+      "queryItems" : [ ],
+      "seriesData" : {
+        "metric" : null
+      },
+      "transient" : false,
+      "type" : "ratio",
+      "uniqueKey" : 5,
+      "valid" : true,
+      "yAxisIndex" : 0
+    }, {
+      "_originalLabel" : "J",
+      "configuration" : {
+        "aliases" : { },
+        "colorOverride" : "#b04600",
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
+        "maxExtrapolations" : -1,
+        "prefix" : "",
+        "suffix" : "",
+        "unitType" : "Byte",
+        "visualization" : "line"
+      },
+      "dataManipulations" : [ {
+        "direction" : {
+          "options" : {
+            "aggregateGroupBy" : [ ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          },
+          "type" : "aggregation"
+        },
+        "fn" : {
+          "options" : {
+            "milliseconds" : 86400000
+          },
+          "type" : "TIMESHIFT"
+        },
+        "showMe" : false
+      } ],
+      "expressionText" : "E",
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "request size (historic)",
+      "queryItems" : [ ],
+      "seriesData" : {
+        "metric" : null
+      },
+      "transient" : false,
+      "type" : "ratio",
+      "uniqueKey" : 10,
+      "valid" : true,
+      "yAxisIndex" : 1
+    }, {
+      "configuration" : {
+        "aliases" : { },
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
+        "maxExtrapolations" : -1
+      },
+      "dataManipulations" : [ ],
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "New Plot",
+      "queryItems" : [ ],
+      "seriesData" : { },
+      "transient" : true,
+      "type" : "plot",
+      "uniqueKey" : 11,
+      "yAxisIndex" : 0
+    } ],
+    "chartMode" : "graph",
+    "chartType" : "area",
+    "chartconfig" : {
+      "absoluteEnd" : null,
+      "absoluteStart" : null,
+      "eventLines" : false,
+      "histogramColor" : "#0077c2",
+      "range" : -900000,
+      "rangeEnd" : null,
+      "secondaryVisualization" : "NONE",
+      "sortPreference" : "",
+      "useKMG2" : false,
+      "yAxisConfigurations" : [ {
+        "id" : "yAxis0",
+        "label" : "bytes/req",
+        "max" : null,
+        "min" : null,
+        "name" : "yAxis0",
+        "plotlines" : {
+          "high" : null,
+          "low" : null
+        }
+      }, {
+        "label" : "bytes/req",
+        "max" : null,
+        "min" : null,
+        "plotlines" : {
+          "high" : null,
+          "low" : null
+        },
+        "title" : {
+          "text" : ""
+        }
+      } ]
+    },
+    "currentUniqueKey" : 12,
+    "relatedDetectors" : [ ],
+    "revisionNumber" : 26,
+    "uiHelperValue" : "##CHARTID##_26"
+  }
+}, {
+  "marshallId" : 41,
+  "marshallMemberOf" : [ 26 ],
+  "sf_chart" : "Upstream Latency",
+  "sf_chartIndex" : 1528135368079,
+  "sf_description" : "Average latency for responses from upstream groups compared with -24h",
+  "sf_type" : "Chart",
+  "sf_uiModel" : {
+    "allPlots" : [ {
+      "_originalLabel" : "A",
+      "configuration" : {
+        "aliases" : { },
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
+        "maxExtrapolations" : -1,
+        "prefix" : "",
+        "rollupPolicy" : "LATEST_ROLLUP",
+        "suffix" : "",
+        "unitType" : "Millisecond"
+      },
+      "dataManipulations" : [ {
+        "direction" : {
+          "options" : {
+            "aggregateGroupBy" : [ {
+              "value" : "host"
+            } ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          },
+          "type" : "aggregation"
+        },
+        "fn" : {
+          "options" : { },
+          "type" : "SUM"
+        },
+        "showMe" : false
+      } ],
+      "invisible" : true,
+      "name" : "counter.kong.upstream.latency - Sum by host",
+      "queryItems" : [ {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "plugin",
+        "propertyValue" : "kong",
+        "type" : "property",
+        "value" : "kong"
+      } ],
+      "seriesData" : {
+        "metric" : "counter.kong.upstream.latency",
+        "regExStyle" : null
+      },
+      "transient" : false,
+      "type" : "plot",
+      "uniqueKey" : 1,
+      "yAxisIndex" : 0
+    }, {
+      "_originalLabel" : "D",
+      "configuration" : {
+        "aliases" : { },
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
+        "maxExtrapolations" : -1,
+        "rollupPolicy" : "LATEST_ROLLUP"
+      },
+      "dataManipulations" : [ {
+        "direction" : {
+          "options" : {
+            "aggregateGroupBy" : [ {
+              "value" : "host"
+            } ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          },
+          "type" : "aggregation"
+        },
+        "fn" : {
+          "options" : { },
+          "type" : "SUM"
+        },
+        "showMe" : false
+      } ],
+      "invisible" : true,
+      "metricDefinition" : { },
+      "name" : "counter.kong.responses.count - Sum by host",
+      "queryItems" : [ {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "plugin",
+        "propertyValue" : "kong",
+        "type" : "property",
+        "value" : "kong"
+      } ],
+      "seriesData" : {
+        "metric" : "counter.kong.responses.count",
+        "regExStyle" : null
+      },
+      "transient" : false,
+      "type" : "plot",
+      "uniqueKey" : 4,
+      "yAxisIndex" : 0
+    }, {
+      "_originalLabel" : "E",
+      "configuration" : {
+        "aliases" : { },
+        "colorOverride" : "#a747ff",
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
+        "maxExtrapolations" : -1,
+        "prefix" : "",
+        "suffix" : "",
+        "unitType" : "Millisecond"
+      },
+      "dataManipulations" : [ ],
+      "expressionText" : "A / D",
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "latency",
+      "queryItems" : [ ],
+      "seriesData" : {
+        "metric" : null
+      },
+      "transient" : false,
+      "type" : "ratio",
+      "uniqueKey" : 5,
+      "valid" : true,
+      "yAxisIndex" : 0
+    }, {
+      "_originalLabel" : "I",
+      "configuration" : {
+        "aliases" : { },
+        "colorOverride" : "#b04600",
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
+        "maxExtrapolations" : -1,
+        "prefix" : "",
+        "suffix" : "",
+        "unitType" : "Millisecond",
+        "visualization" : "line"
+      },
+      "dataManipulations" : [ {
+        "direction" : {
+          "options" : {
+            "aggregateGroupBy" : [ ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          },
+          "type" : "aggregation"
+        },
+        "fn" : {
+          "options" : {
+            "milliseconds" : 86400000
+          },
+          "type" : "TIMESHIFT"
+        },
+        "showMe" : false
+      } ],
+      "expressionText" : "E",
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "latency (historic)",
+      "queryItems" : [ ],
+      "seriesData" : {
+        "metric" : null
+      },
+      "transient" : false,
+      "type" : "ratio",
+      "uniqueKey" : 9,
+      "valid" : true,
+      "yAxisIndex" : 1
+    }, {
+      "configuration" : {
+        "aliases" : { },
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
+        "maxExtrapolations" : -1
+      },
+      "dataManipulations" : [ ],
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "New Plot",
+      "queryItems" : [ ],
+      "seriesData" : { },
+      "transient" : true,
+      "type" : "plot",
+      "uniqueKey" : 10,
+      "yAxisIndex" : 0
+    } ],
+    "chartMode" : "graph",
+    "chartType" : "area",
+    "chartconfig" : {
+      "absoluteEnd" : null,
+      "absoluteStart" : null,
+      "histogramColor" : "#ea1849",
+      "range" : -900000,
+      "rangeEnd" : null,
+      "secondaryVisualization" : "NONE",
+      "sortPreference" : "",
+      "useKMG2" : false,
+      "yAxisConfigurations" : [ {
+        "id" : "yAxis0",
+        "label" : "latency/resp",
+        "max" : null,
+        "min" : null,
+        "name" : "yAxis0",
+        "plotlines" : {
+          "high" : null,
+          "low" : null
+        }
+      }, {
+        "label" : "latency/resp",
+        "max" : null,
+        "min" : null,
+        "plotlines" : {
+          "high" : null,
+          "low" : null
+        },
+        "title" : {
+          "text" : ""
+        }
+      } ]
+    },
+    "currentUniqueKey" : 11,
+    "revisionNumber" : 25,
+    "uiHelperValue" : "##CHARTID##_25"
+  }
+}, {
+  "marshallId" : 42,
+  "marshallMemberOf" : [ 26 ],
+  "sf_chart" : "Responses / Second",
+  "sf_chartIndex" : 1528219376990,
+  "sf_description" : "Rate of Service/API responses",
+  "sf_type" : "Chart",
+  "sf_uiModel" : {
+    "allPlots" : [ {
+      "_originalLabel" : "A",
+      "configuration" : {
+        "aliases" : { },
+        "colorOverride" : null,
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
+        "maxExtrapolations" : -1,
+        "prefix" : "",
+        "suffix" : "responses",
+        "unitType" : null
+      },
+      "dataManipulations" : [ {
+        "direction" : {
+          "options" : {
+            "aggregateGroupBy" : [ {
+              "value" : "host"
+            } ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          },
+          "type" : "aggregation"
+        },
+        "fn" : {
+          "options" : { },
+          "type" : "SUM"
+        },
+        "showMe" : false
+      } ],
+      "invisible" : false,
+      "name" : "upstream responses",
+      "queryItems" : [ {
+        "NOT" : false,
+        "iconClass" : "sf-icon-property",
+        "property" : "plugin",
+        "propertyValue" : "kong",
+        "query" : "plugin:\"kong\"",
+        "type" : "property",
+        "value" : "kong"
+      } ],
+      "seriesData" : {
+        "metric" : "counter.kong.responses.count"
+      },
+      "transient" : false,
+      "type" : "plot",
+      "uniqueKey" : 1,
+      "yAxisIndex" : 0
+    }, {
+      "configuration" : {
+        "aliases" : { },
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
+        "maxExtrapolations" : -1
+      },
+      "dataManipulations" : [ ],
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "New Plot",
+      "queryItems" : [ ],
+      "seriesData" : { },
+      "transient" : true,
+      "type" : "plot",
+      "uniqueKey" : 2,
+      "yAxisIndex" : 0
+    } ],
+    "chartMode" : "graph",
+    "chartType" : "area",
+    "chartconfig" : {
+      "absoluteEnd" : null,
+      "absoluteStart" : null,
+      "colorByMetric" : false,
+      "colorByValue" : false,
+      "colorByValueScale" : [ ],
+      "hideTimestamp" : false,
+      "histogramColor" : "#ea1849",
+      "maxDecimalPlaces" : 2,
+      "range" : -3600000,
+      "rangeEnd" : 0,
+      "secondaryVisualization" : "NONE",
+      "sortPreference" : "",
+      "stackedChart" : true,
+      "useKMG2" : false,
+      "yAxisConfigurations" : [ {
+        "id" : "yAxis0",
+        "label" : "resp/s",
+        "max" : null,
+        "min" : null,
+        "name" : "yAxis0",
+        "plotlines" : {
+          "high" : null,
+          "low" : null
+        }
+      } ]
+    },
+    "currentUniqueKey" : 3,
+    "relatedDetectors" : [ ],
+    "revisionNumber" : 23,
+    "uiHelperValue" : "##CHARTID##_23"
+  }
+}, {
+  "marshallId" : 43,
+  "marshallMemberOf" : [ 1 ],
+  "sf_dashboard" : "Kong Server Overview",
+  "sf_description" : "High-level Kong performance for individual server",
+  "sf_discoveryQuery" : "plugin:kong",
+  "sf_discoverySelectors" : [ "__exists__:host", "plugin:kong" ],
+  "sf_filterAlias" : {
+    "variables" : [ {
+      "alias" : "Kong Instance",
+      "applyIfExists" : false,
+      "description" : "",
+      "dimension" : "host",
+      "globalScope" : false,
+      "preferredSuggestions" : [ ],
+      "replaceOnly" : false,
+      "required" : true,
+      "restricted" : false,
+      "value" : ""
+    } ]
+  },
+  "sf_isLocked" : false,
+  "sf_maxDelayOverride" : -1,
+  "sf_savedFilters" : {
+    "density" : 0.0,
+    "sources" : null,
+    "time" : {
+      "end" : "Now",
+      "relative" : true,
+      "start" : "-1h"
+    },
+    "variables" : [ "Kong Instance=host:" ]
+  },
+  "sf_selectedEventOverlays" : [ ],
+  "sf_type" : "Dashboard",
+  "sf_uiModel" : {
+    "version" : 1,
+    "widgets" : [ {
+      "col" : 0,
+      "options" : {
+        "chartIndex" : 1528137157576,
+        "id" : 0
+      },
+      "row" : 0,
+      "sizeX" : 3,
+      "sizeY" : 2
+    }, {
+      "col" : 3,
+      "options" : {
+        "chartIndex" : 1528227295288,
+        "id" : 0
+      },
+      "row" : 0,
+      "sizeX" : 3,
+      "sizeY" : 1
+    }, {
+      "col" : 6,
+      "options" : {
+        "chartIndex" : 1528137043591,
+        "id" : 0
+      },
+      "row" : 0,
+      "sizeX" : 6,
+      "sizeY" : 1
+    }, {
+      "col" : 3,
+      "options" : {
+        "chartIndex" : 1528134810674,
+        "id" : 0
+      },
+      "row" : 1,
+      "sizeX" : 3,
+      "sizeY" : 1
+    }, {
+      "col" : 6,
+      "options" : {
+        "chartIndex" : 1528219376990,
+        "id" : 0
+      },
+      "row" : 1,
+      "sizeX" : 6,
+      "sizeY" : 1
+    }, {
+      "col" : 0,
+      "options" : {
+        "chartIndex" : 1528729931437,
+        "id" : 0
+      },
+      "row" : 2,
+      "sizeX" : 6,
+      "sizeY" : 1
+    }, {
+      "col" : 9,
+      "options" : {
+        "chartIndex" : 1528135823509,
+        "id" : 0
+      },
+      "row" : 2,
+      "sizeX" : 3,
+      "sizeY" : 2
+    }, {
+      "col" : 6,
+      "options" : {
+        "chartIndex" : 1528138165800,
+        "id" : 0
+      },
+      "row" : 2,
+      "sizeX" : 3,
+      "sizeY" : 2
+    }, {
+      "col" : 0,
+      "options" : {
+        "chartIndex" : 1528136271804,
+        "id" : 0
+      },
+      "row" : 3,
+      "sizeX" : 6,
+      "sizeY" : 2
+    }, {
+      "col" : 6,
+      "options" : {
+        "chartIndex" : 1528311465641,
+        "id" : 0
+      },
+      "row" : 4,
+      "sizeX" : 6,
+      "sizeY" : 1
+    }, {
+      "col" : 0,
+      "options" : {
+        "chartIndex" : 1528311465640,
+        "id" : 0
+      },
+      "row" : 5,
+      "sizeX" : 6,
+      "sizeY" : 1
+    }, {
+      "col" : 6,
+      "options" : {
+        "chartIndex" : 1528146664212,
+        "id" : 0
+      },
+      "row" : 5,
+      "sizeX" : 6,
+      "sizeY" : 2
+    }, {
+      "col" : 0,
+      "options" : {
+        "chartIndex" : 1528139299895,
+        "id" : 0
+      },
+      "row" : 6,
+      "sizeX" : 6,
+      "sizeY" : 2
+    }, {
+      "col" : 6,
+      "options" : {
+        "chartIndex" : 1528147046843,
+        "id" : 0
+      },
+      "row" : 7,
+      "sizeX" : 6,
+      "sizeY" : 2
+    }, {
+      "col" : 0,
+      "options" : {
+        "chartIndex" : 1528135368079,
+        "id" : 0
+      },
+      "row" : 8,
+      "sizeX" : 6,
+      "sizeY" : 2
+    } ]
+  }
+}, {
+  "marshallId" : 44,
+  "marshallMemberOf" : [ 43 ],
   "sf_chart" : "Request Size",
   "sf_chartIndex" : 1528146664212,
   "sf_description" : "5 largest average sizes of upstream-fielded client requests by Service/API compared with -24h overall average",
@@ -7692,8 +8865,327 @@
     "uiHelperValue" : "##CHARTID##_31"
   }
 }, {
-  "marshallId" : 36,
-  "marshallMemberOf" : [ 26 ],
+  "marshallId" : 45,
+  "marshallMemberOf" : [ 43 ],
+  "sf_chart" : "Responses / Second",
+  "sf_chartIndex" : 1528134810674,
+  "sf_description" : "Rate of responses from Kong",
+  "sf_type" : "Chart",
+  "sf_uiModel" : {
+    "allPlots" : [ {
+      "_originalLabel" : "A",
+      "configuration" : {
+        "aliases" : { },
+        "colorOverride" : "#0077c2",
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
+        "maxExtrapolations" : -1,
+        "prefix" : "",
+        "suffix" : "",
+        "unitType" : null
+      },
+      "dataManipulations" : [ {
+        "direction" : {
+          "options" : {
+            "aggregateGroupBy" : [ ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          },
+          "type" : "aggregation"
+        },
+        "fn" : {
+          "options" : { },
+          "type" : "SUM"
+        },
+        "showMe" : false
+      } ],
+      "invisible" : false,
+      "name" : "responses",
+      "queryItems" : [ {
+        "NOT" : false,
+        "iconClass" : "sf-icon-property",
+        "property" : "plugin",
+        "propertyValue" : "kong",
+        "query" : "plugin:\"kong\"",
+        "type" : "property",
+        "value" : "kong"
+      } ],
+      "seriesData" : {
+        "metric" : "counter.kong.responses.count"
+      },
+      "transient" : false,
+      "type" : "plot",
+      "uniqueKey" : 1,
+      "yAxisIndex" : 0
+    }, {
+      "configuration" : {
+        "aliases" : { },
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
+        "maxExtrapolations" : -1
+      },
+      "dataManipulations" : [ ],
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "New Plot",
+      "queryItems" : [ ],
+      "seriesData" : { },
+      "transient" : true,
+      "type" : "plot",
+      "uniqueKey" : 2,
+      "yAxisIndex" : 0
+    } ],
+    "chartMode" : "single",
+    "chartType" : "line",
+    "chartconfig" : {
+      "absoluteEnd" : null,
+      "absoluteStart" : null,
+      "colorByMetric" : false,
+      "colorByValue" : false,
+      "colorByValueScale" : [ ],
+      "hideTimestamp" : false,
+      "histogramColor" : "#ea1849",
+      "maxDecimalPlaces" : 2,
+      "range" : -1800000,
+      "rangeEnd" : 0,
+      "secondaryVisualization" : "NONE",
+      "sortPreference" : "",
+      "useKMG2" : false,
+      "yAxisConfigurations" : [ {
+        "id" : "yAxis0",
+        "max" : null,
+        "min" : null,
+        "name" : "yAxis0",
+        "plotlines" : {
+          "high" : null,
+          "low" : null
+        }
+      } ]
+    },
+    "currentUniqueKey" : 3,
+    "relatedDetectors" : [ ],
+    "revisionNumber" : 15,
+    "uiHelperValue" : "##CHARTID##_15"
+  }
+}, {
+  "marshallId" : 46,
+  "marshallMemberOf" : [ 43 ],
+  "sf_chart" : "Connections by State",
+  "sf_chartIndex" : 1528135823509,
+  "sf_description" : "Number of connections in each state",
+  "sf_type" : "Chart",
+  "sf_uiModel" : {
+    "allPlots" : [ {
+      "_originalLabel" : "A",
+      "configuration" : {
+        "aliases" : { },
+        "colorOverride" : "#007c1d",
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
+        "maxExtrapolations" : -1,
+        "rollupPolicy" : "SUM_ROLLUP"
+      },
+      "dataManipulations" : [ {
+        "direction" : {
+          "options" : {
+            "aggregateGroupBy" : [ ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          },
+          "type" : "aggregation"
+        },
+        "fn" : {
+          "options" : { },
+          "type" : "SUM"
+        },
+        "showMe" : false
+      } ],
+      "invisible" : false,
+      "name" : "active",
+      "queryItems" : [ {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "plugin",
+        "propertyValue" : "kong",
+        "type" : "property",
+        "value" : "kong"
+      } ],
+      "seriesData" : {
+        "metric" : "gauge.kong.connections.active"
+      },
+      "transient" : false,
+      "type" : "plot",
+      "uniqueKey" : 1,
+      "yAxisIndex" : 0
+    }, {
+      "_originalLabel" : "B",
+      "configuration" : {
+        "aliases" : { },
+        "colorOverride" : "#ff8dd1",
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
+        "maxExtrapolations" : -1,
+        "rollupPolicy" : "SUM_ROLLUP"
+      },
+      "dataManipulations" : [ {
+        "direction" : {
+          "options" : {
+            "aggregateGroupBy" : [ ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          },
+          "type" : "aggregation"
+        },
+        "fn" : {
+          "options" : { },
+          "type" : "SUM"
+        },
+        "showMe" : false
+      } ],
+      "invisible" : false,
+      "name" : "reading",
+      "queryItems" : [ {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "plugin",
+        "propertyValue" : "kong",
+        "type" : "property",
+        "value" : "kong"
+      } ],
+      "seriesData" : {
+        "metric" : "gauge.kong.connections.reading"
+      },
+      "transient" : false,
+      "type" : "plot",
+      "uniqueKey" : 2,
+      "yAxisIndex" : 0
+    }, {
+      "_originalLabel" : "C",
+      "configuration" : {
+        "aliases" : { },
+        "colorOverride" : "#e9008a",
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
+        "maxExtrapolations" : -1,
+        "rollupPolicy" : "SUM_ROLLUP"
+      },
+      "dataManipulations" : [ {
+        "direction" : {
+          "options" : {
+            "aggregateGroupBy" : [ ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          },
+          "type" : "aggregation"
+        },
+        "fn" : {
+          "options" : { },
+          "type" : "SUM"
+        },
+        "showMe" : false
+      } ],
+      "invisible" : false,
+      "name" : "waiting",
+      "queryItems" : [ {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "plugin",
+        "propertyValue" : "kong",
+        "type" : "property",
+        "value" : "kong"
+      } ],
+      "seriesData" : {
+        "metric" : "gauge.kong.connections.waiting"
+      },
+      "transient" : false,
+      "type" : "plot",
+      "uniqueKey" : 3,
+      "yAxisIndex" : 0
+    }, {
+      "_originalLabel" : "D",
+      "configuration" : {
+        "aliases" : { },
+        "colorOverride" : "#00b9ff",
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
+        "maxExtrapolations" : -1,
+        "rollupPolicy" : "SUM_ROLLUP"
+      },
+      "dataManipulations" : [ {
+        "direction" : {
+          "options" : {
+            "aggregateGroupBy" : [ ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          },
+          "type" : "aggregation"
+        },
+        "fn" : {
+          "options" : { },
+          "type" : "SUM"
+        },
+        "showMe" : false
+      } ],
+      "invisible" : false,
+      "name" : "writing",
+      "queryItems" : [ {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "plugin",
+        "propertyValue" : "kong",
+        "type" : "property",
+        "value" : "kong"
+      } ],
+      "seriesData" : {
+        "metric" : "gauge.kong.connections.writing"
+      },
+      "transient" : false,
+      "type" : "plot",
+      "uniqueKey" : 4,
+      "yAxisIndex" : 0
+    }, {
+      "configuration" : {
+        "aliases" : { },
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
+        "maxExtrapolations" : -1
+      },
+      "dataManipulations" : [ ],
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "New Plot",
+      "queryItems" : [ ],
+      "seriesData" : { },
+      "transient" : true,
+      "type" : "plot",
+      "uniqueKey" : 10,
+      "yAxisIndex" : 0
+    } ],
+    "chartMode" : "list",
+    "chartType" : "line",
+    "chartconfig" : {
+      "absoluteEnd" : null,
+      "absoluteStart" : null,
+      "colorByMetric" : false,
+      "colorByValue" : false,
+      "colorByValueScale" : [ ],
+      "histogramColor" : "#ea1849",
+      "range" : -1800000,
+      "rangeEnd" : 0,
+      "secondaryVisualization" : "SPARKLINE",
+      "sortPreference" : "",
+      "useKMG2" : false,
+      "yAxisConfigurations" : [ {
+        "id" : "yAxis0",
+        "max" : null,
+        "min" : null,
+        "name" : "yAxis0",
+        "plotlines" : {
+          "high" : null,
+          "low" : null
+        }
+      } ]
+    },
+    "currentUniqueKey" : 11,
+    "relatedDetectors" : [ ],
+    "revisionNumber" : 11
+  }
+}, {
+  "marshallId" : 47,
+  "marshallMemberOf" : [ 43 ],
   "sf_chart" : "Kong Latency",
   "sf_chartIndex" : 1528147046843,
   "sf_description" : "5 largest average Kong-induced latencies for requests by Service/API compared with -24h overall average",
@@ -8239,11 +9731,11 @@
     "uiHelperValue" : "##CHARTID##_24"
   }
 }, {
-  "marshallId" : 37,
-  "marshallMemberOf" : [ 26 ],
-  "sf_chart" : "Connections by State",
-  "sf_chartIndex" : 1528135823509,
-  "sf_description" : "Number of connections in each state",
+  "marshallId" : 48,
+  "marshallMemberOf" : [ 43 ],
+  "sf_chart" : "Requests / Second",
+  "sf_chartIndex" : 1528137043591,
+  "sf_description" : "Rate of total requests made to Kong",
   "sf_type" : "Chart",
   "sf_uiModel" : {
     "allPlots" : [ {
@@ -8253,12 +9745,15 @@
         "colorOverride" : "#007c1d",
         "extrapolationPolicy" : "NULL_EXTRAPOLATION",
         "maxExtrapolations" : -1,
-        "rollupPolicy" : "SUM_ROLLUP"
+        "suffix" : "requests",
+        "unitType" : null
       },
       "dataManipulations" : [ {
         "direction" : {
           "options" : {
-            "aggregateGroupBy" : [ ],
+            "aggregateGroupBy" : [ {
+              "value" : "host"
+            } ],
             "collapseGroups" : false,
             "transformTimeRange" : null
           },
@@ -8271,7 +9766,7 @@
         "showMe" : false
       } ],
       "invisible" : false,
-      "name" : "active",
+      "name" : "total requests",
       "queryItems" : [ {
         "NOT" : false,
         "iconClass" : "icon-properties",
@@ -8281,134 +9776,11 @@
         "value" : "kong"
       } ],
       "seriesData" : {
-        "metric" : "gauge.kong.connections.active"
+        "metric" : "counter.kong.requests.count"
       },
       "transient" : false,
       "type" : "plot",
       "uniqueKey" : 1,
-      "yAxisIndex" : 0
-    }, {
-      "_originalLabel" : "B",
-      "configuration" : {
-        "aliases" : { },
-        "colorOverride" : "#ff8dd1",
-        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
-        "maxExtrapolations" : -1,
-        "rollupPolicy" : "SUM_ROLLUP"
-      },
-      "dataManipulations" : [ {
-        "direction" : {
-          "options" : {
-            "aggregateGroupBy" : [ ],
-            "collapseGroups" : false,
-            "transformTimeRange" : null
-          },
-          "type" : "aggregation"
-        },
-        "fn" : {
-          "options" : { },
-          "type" : "SUM"
-        },
-        "showMe" : false
-      } ],
-      "invisible" : false,
-      "name" : "reading",
-      "queryItems" : [ {
-        "NOT" : false,
-        "iconClass" : "icon-properties",
-        "property" : "plugin",
-        "propertyValue" : "kong",
-        "type" : "property",
-        "value" : "kong"
-      } ],
-      "seriesData" : {
-        "metric" : "gauge.kong.connections.reading"
-      },
-      "transient" : false,
-      "type" : "plot",
-      "uniqueKey" : 2,
-      "yAxisIndex" : 0
-    }, {
-      "_originalLabel" : "C",
-      "configuration" : {
-        "aliases" : { },
-        "colorOverride" : "#e9008a",
-        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
-        "maxExtrapolations" : -1,
-        "rollupPolicy" : "SUM_ROLLUP"
-      },
-      "dataManipulations" : [ {
-        "direction" : {
-          "options" : {
-            "aggregateGroupBy" : [ ],
-            "collapseGroups" : false,
-            "transformTimeRange" : null
-          },
-          "type" : "aggregation"
-        },
-        "fn" : {
-          "options" : { },
-          "type" : "SUM"
-        },
-        "showMe" : false
-      } ],
-      "invisible" : false,
-      "name" : "waiting",
-      "queryItems" : [ {
-        "NOT" : false,
-        "iconClass" : "icon-properties",
-        "property" : "plugin",
-        "propertyValue" : "kong",
-        "type" : "property",
-        "value" : "kong"
-      } ],
-      "seriesData" : {
-        "metric" : "gauge.kong.connections.waiting"
-      },
-      "transient" : false,
-      "type" : "plot",
-      "uniqueKey" : 3,
-      "yAxisIndex" : 0
-    }, {
-      "_originalLabel" : "D",
-      "configuration" : {
-        "aliases" : { },
-        "colorOverride" : "#00b9ff",
-        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
-        "maxExtrapolations" : -1,
-        "rollupPolicy" : "SUM_ROLLUP"
-      },
-      "dataManipulations" : [ {
-        "direction" : {
-          "options" : {
-            "aggregateGroupBy" : [ ],
-            "collapseGroups" : false,
-            "transformTimeRange" : null
-          },
-          "type" : "aggregation"
-        },
-        "fn" : {
-          "options" : { },
-          "type" : "SUM"
-        },
-        "showMe" : false
-      } ],
-      "invisible" : false,
-      "name" : "writing",
-      "queryItems" : [ {
-        "NOT" : false,
-        "iconClass" : "icon-properties",
-        "property" : "plugin",
-        "propertyValue" : "kong",
-        "type" : "property",
-        "value" : "kong"
-      } ],
-      "seriesData" : {
-        "metric" : "gauge.kong.connections.writing"
-      },
-      "transient" : false,
-      "type" : "plot",
-      "uniqueKey" : 4,
       "yAxisIndex" : 0
     }, {
       "configuration" : {
@@ -8424,25 +9796,24 @@
       "seriesData" : { },
       "transient" : true,
       "type" : "plot",
-      "uniqueKey" : 10,
+      "uniqueKey" : 3,
       "yAxisIndex" : 0
     } ],
-    "chartMode" : "list",
-    "chartType" : "line",
+    "chartMode" : "graph",
+    "chartType" : "area",
     "chartconfig" : {
       "absoluteEnd" : null,
       "absoluteStart" : null,
       "colorByMetric" : false,
-      "colorByValue" : false,
-      "colorByValueScale" : [ ],
       "histogramColor" : "#ea1849",
-      "range" : -1800000,
-      "rangeEnd" : 0,
-      "secondaryVisualization" : "SPARKLINE",
+      "range" : -900000,
+      "rangeEnd" : null,
+      "secondaryVisualization" : "NONE",
       "sortPreference" : "",
       "useKMG2" : false,
       "yAxisConfigurations" : [ {
         "id" : "yAxis0",
+        "label" : "req/s",
         "max" : null,
         "min" : null,
         "name" : "yAxis0",
@@ -8452,13 +9823,13 @@
         }
       } ]
     },
-    "currentUniqueKey" : 11,
+    "currentUniqueKey" : 4,
     "relatedDetectors" : [ ],
-    "revisionNumber" : 11
+    "revisionNumber" : 13
   }
 }, {
-  "marshallId" : 38,
-  "marshallMemberOf" : [ 26 ],
+  "marshallId" : 49,
+  "marshallMemberOf" : [ 43 ],
   "sf_chart" : "Upstream Latency",
   "sf_chartIndex" : 1528135368079,
   "sf_description" : "5 largest average latencies for responses from upstream groups by Service/API compared with -24h overall average",
@@ -8992,28 +10363,28 @@
     "uiHelperValue" : "##CHARTID##_27"
   }
 }, {
-  "marshallId" : 39,
-  "marshallMemberOf" : [ 26 ],
-  "sf_chart" : "Requests / Second",
-  "sf_chartIndex" : 1528137043591,
-  "sf_description" : "Rate of total requests made to Kong",
+  "marshallId" : 50,
+  "marshallMemberOf" : [ 43 ],
+  "sf_chart" : "Requests by HTTP Method",
+  "sf_chartIndex" : 1528138165800,
+  "sf_description" : "Rate of Service/API-fielded requests by HTTP method",
   "sf_type" : "Chart",
   "sf_uiModel" : {
     "allPlots" : [ {
       "_originalLabel" : "A",
       "configuration" : {
         "aliases" : { },
-        "colorOverride" : "#007c1d",
+        "colorOverride" : null,
         "extrapolationPolicy" : "NULL_EXTRAPOLATION",
         "maxExtrapolations" : -1,
-        "suffix" : "requests",
+        "suffix" : "req/s",
         "unitType" : null
       },
       "dataManipulations" : [ {
         "direction" : {
           "options" : {
             "aggregateGroupBy" : [ {
-              "value" : "host"
+              "value" : "http_method"
             } ],
             "collapseGroups" : false,
             "transformTimeRange" : null
@@ -9027,7 +10398,7 @@
         "showMe" : false
       } ],
       "invisible" : false,
-      "name" : "total requests",
+      "name" : "",
       "queryItems" : [ {
         "NOT" : false,
         "iconClass" : "icon-properties",
@@ -9037,7 +10408,7 @@
         "value" : "kong"
       } ],
       "seriesData" : {
-        "metric" : "counter.kong.requests.count"
+        "metric" : "counter.kong.responses.count"
       },
       "transient" : false,
       "type" : "plot",
@@ -9057,24 +10428,26 @@
       "seriesData" : { },
       "transient" : true,
       "type" : "plot",
-      "uniqueKey" : 3,
+      "uniqueKey" : 18,
       "yAxisIndex" : 0
     } ],
-    "chartMode" : "graph",
-    "chartType" : "area",
+    "chartMode" : "list",
+    "chartType" : "line",
     "chartconfig" : {
       "absoluteEnd" : null,
       "absoluteStart" : null,
       "colorByMetric" : false,
+      "colorByValue" : false,
+      "colorByValueScale" : [ ],
       "histogramColor" : "#ea1849",
-      "range" : -900000,
-      "rangeEnd" : null,
-      "secondaryVisualization" : "NONE",
-      "sortPreference" : "",
+      "maxDecimalPlaces" : 4,
+      "range" : -1800000,
+      "rangeEnd" : 0,
+      "secondaryVisualization" : "SPARKLINE",
+      "sortPreference" : "+http_method",
       "useKMG2" : false,
       "yAxisConfigurations" : [ {
         "id" : "yAxis0",
-        "label" : "req/s",
         "max" : null,
         "min" : null,
         "name" : "yAxis0",
@@ -9084,13 +10457,14 @@
         }
       } ]
     },
-    "currentUniqueKey" : 4,
+    "currentUniqueKey" : 19,
     "relatedDetectors" : [ ],
-    "revisionNumber" : 13
+    "revisionNumber" : 19,
+    "uiHelperValue" : "##CHARTID##_19"
   }
 }, {
-  "marshallId" : 40,
-  "marshallMemberOf" : [ 26 ],
+  "marshallId" : 51,
+  "marshallMemberOf" : [ 43 ],
   "sf_chart" : "Bytes Out / Second",
   "sf_chartIndex" : 1528311465640,
   "sf_description" : "Service/API response transfer rate compared with -24h",
@@ -9238,1252 +10612,8 @@
     "uiHelperValue" : "##CHARTID##_8"
   }
 }, {
-  "marshallId" : 41,
-  "marshallMemberOf" : [ 26 ],
-  "sf_chart" : "Requests by HTTP Method",
-  "sf_chartIndex" : 1528138165800,
-  "sf_description" : "Rate of Service/API-fielded requests by HTTP method",
-  "sf_type" : "Chart",
-  "sf_uiModel" : {
-    "allPlots" : [ {
-      "_originalLabel" : "A",
-      "configuration" : {
-        "aliases" : { },
-        "colorOverride" : null,
-        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
-        "maxExtrapolations" : -1,
-        "suffix" : "req/s",
-        "unitType" : null
-      },
-      "dataManipulations" : [ {
-        "direction" : {
-          "options" : {
-            "aggregateGroupBy" : [ {
-              "value" : "http_method"
-            } ],
-            "collapseGroups" : false,
-            "transformTimeRange" : null
-          },
-          "type" : "aggregation"
-        },
-        "fn" : {
-          "options" : { },
-          "type" : "SUM"
-        },
-        "showMe" : false
-      } ],
-      "invisible" : false,
-      "name" : "",
-      "queryItems" : [ {
-        "NOT" : false,
-        "iconClass" : "icon-properties",
-        "property" : "plugin",
-        "propertyValue" : "kong",
-        "type" : "property",
-        "value" : "kong"
-      } ],
-      "seriesData" : {
-        "metric" : "counter.kong.responses.count"
-      },
-      "transient" : false,
-      "type" : "plot",
-      "uniqueKey" : 1,
-      "yAxisIndex" : 0
-    }, {
-      "configuration" : {
-        "aliases" : { },
-        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
-        "maxExtrapolations" : -1
-      },
-      "dataManipulations" : [ ],
-      "invisible" : false,
-      "metricDefinition" : { },
-      "name" : "New Plot",
-      "queryItems" : [ ],
-      "seriesData" : { },
-      "transient" : true,
-      "type" : "plot",
-      "uniqueKey" : 18,
-      "yAxisIndex" : 0
-    } ],
-    "chartMode" : "list",
-    "chartType" : "line",
-    "chartconfig" : {
-      "absoluteEnd" : null,
-      "absoluteStart" : null,
-      "colorByMetric" : false,
-      "colorByValue" : false,
-      "colorByValueScale" : [ ],
-      "histogramColor" : "#ea1849",
-      "maxDecimalPlaces" : 4,
-      "range" : -1800000,
-      "rangeEnd" : 0,
-      "secondaryVisualization" : "SPARKLINE",
-      "sortPreference" : "+http_method",
-      "useKMG2" : false,
-      "yAxisConfigurations" : [ {
-        "id" : "yAxis0",
-        "max" : null,
-        "min" : null,
-        "name" : "yAxis0",
-        "plotlines" : {
-          "high" : null,
-          "low" : null
-        }
-      } ]
-    },
-    "currentUniqueKey" : 19,
-    "relatedDetectors" : [ ],
-    "revisionNumber" : 19,
-    "uiHelperValue" : "##CHARTID##_19"
-  }
-}, {
-  "marshallId" : 42,
-  "marshallMemberOf" : [ 1 ],
-  "sf_dashboard" : "Kong Servers Overview",
-  "sf_description" : "High-level Kong performance for all reporting servers",
-  "sf_discoveryQuery" : "plugin:kong",
-  "sf_discoverySelectors" : [ "__exists__:host", "plugin:kong" ],
-  "sf_filterAlias" : {
-    "variables" : [ ]
-  },
-  "sf_isLocked" : false,
-  "sf_maxDelayOverride" : -1,
-  "sf_savedFilters" : {
-    "density" : 0.0,
-    "sources" : null,
-    "time" : {
-      "end" : "Now",
-      "relative" : true,
-      "start" : "-1h"
-    },
-    "variables" : null
-  },
-  "sf_selectedEventOverlays" : [ ],
-  "sf_type" : "Dashboard",
-  "sf_uiModel" : {
-    "version" : 1,
-    "widgets" : [ {
-      "col" : 0,
-      "options" : {
-        "chartIndex" : 1528220571437,
-        "id" : 0
-      },
-      "row" : 0,
-      "sizeX" : 3,
-      "sizeY" : 1
-    }, {
-      "col" : 3,
-      "options" : {
-        "chartIndex" : 1528227295288,
-        "id" : 0
-      },
-      "row" : 0,
-      "sizeX" : 3,
-      "sizeY" : 1
-    }, {
-      "col" : 6,
-      "options" : {
-        "chartIndex" : 1528137043591,
-        "id" : 0
-      },
-      "row" : 0,
-      "sizeX" : 6,
-      "sizeY" : 1
-    }, {
-      "col" : 0,
-      "options" : {
-        "chartIndex" : 1528137157576,
-        "id" : 0
-      },
-      "row" : 1,
-      "sizeX" : 3,
-      "sizeY" : 1
-    }, {
-      "col" : 6,
-      "options" : {
-        "chartIndex" : 1528219376990,
-        "id" : 0
-      },
-      "row" : 1,
-      "sizeX" : 6,
-      "sizeY" : 1
-    }, {
-      "col" : 3,
-      "options" : {
-        "chartIndex" : 1528134810674,
-        "id" : 0
-      },
-      "row" : 1,
-      "sizeX" : 3,
-      "sizeY" : 1
-    }, {
-      "col" : 0,
-      "options" : {
-        "chartIndex" : 1528729536811,
-        "id" : 0
-      },
-      "row" : 2,
-      "sizeX" : 6,
-      "sizeY" : 1
-    }, {
-      "col" : 6,
-      "options" : {
-        "chartIndex" : 1528138165800,
-        "id" : 0
-      },
-      "row" : 2,
-      "sizeX" : 3,
-      "sizeY" : 2
-    }, {
-      "col" : 9,
-      "options" : {
-        "chartIndex" : 1528135823509,
-        "id" : 0
-      },
-      "row" : 2,
-      "sizeX" : 3,
-      "sizeY" : 2
-    }, {
-      "col" : 0,
-      "options" : {
-        "chartIndex" : 1528136271804,
-        "id" : 0
-      },
-      "row" : 3,
-      "sizeX" : 6,
-      "sizeY" : 1
-    }, {
-      "col" : 6,
-      "options" : {
-        "chartIndex" : 1528311013969,
-        "id" : 0
-      },
-      "row" : 4,
-      "sizeX" : 6,
-      "sizeY" : 1
-    }, {
-      "col" : 0,
-      "options" : {
-        "chartIndex" : 1528310523139,
-        "id" : 0
-      },
-      "row" : 4,
-      "sizeX" : 6,
-      "sizeY" : 1
-    }, {
-      "col" : 6,
-      "options" : {
-        "chartIndex" : 1528146664212,
-        "id" : 0
-      },
-      "row" : 5,
-      "sizeX" : 6,
-      "sizeY" : 1
-    }, {
-      "col" : 0,
-      "options" : {
-        "chartIndex" : 1528139299895,
-        "id" : 0
-      },
-      "row" : 5,
-      "sizeX" : 6,
-      "sizeY" : 1
-    }, {
-      "col" : 6,
-      "options" : {
-        "chartIndex" : 1528147046843,
-        "id" : 0
-      },
-      "row" : 6,
-      "sizeX" : 6,
-      "sizeY" : 1
-    }, {
-      "col" : 0,
-      "options" : {
-        "chartIndex" : 1528135368079,
-        "id" : 0
-      },
-      "row" : 6,
-      "sizeX" : 6,
-      "sizeY" : 1
-    } ]
-  }
-}, {
-  "marshallId" : 43,
-  "marshallMemberOf" : [ 42 ],
-  "sf_chart" : "Responses / Second",
-  "sf_chartIndex" : 1528134810674,
-  "sf_description" : "Rate of upstream responses",
-  "sf_type" : "Chart",
-  "sf_uiModel" : {
-    "allPlots" : [ {
-      "_originalLabel" : "A",
-      "configuration" : {
-        "aliases" : { },
-        "colorOverride" : "#0077c2",
-        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
-        "maxExtrapolations" : -1,
-        "prefix" : "",
-        "suffix" : "",
-        "unitType" : null
-      },
-      "dataManipulations" : [ {
-        "direction" : {
-          "options" : {
-            "aggregateGroupBy" : [ ],
-            "collapseGroups" : false,
-            "transformTimeRange" : null
-          },
-          "type" : "aggregation"
-        },
-        "fn" : {
-          "options" : { },
-          "type" : "SUM"
-        },
-        "showMe" : false
-      } ],
-      "invisible" : false,
-      "name" : "responses",
-      "queryItems" : [ {
-        "NOT" : false,
-        "iconClass" : "sf-icon-property",
-        "property" : "plugin",
-        "propertyValue" : "kong",
-        "query" : "plugin:\"kong\"",
-        "type" : "property",
-        "value" : "kong"
-      } ],
-      "seriesData" : {
-        "metric" : "counter.kong.responses.count"
-      },
-      "transient" : false,
-      "type" : "plot",
-      "uniqueKey" : 1,
-      "yAxisIndex" : 0
-    }, {
-      "configuration" : {
-        "aliases" : { },
-        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
-        "maxExtrapolations" : -1
-      },
-      "dataManipulations" : [ ],
-      "invisible" : false,
-      "metricDefinition" : { },
-      "name" : "New Plot",
-      "queryItems" : [ ],
-      "seriesData" : { },
-      "transient" : true,
-      "type" : "plot",
-      "uniqueKey" : 2,
-      "yAxisIndex" : 0
-    } ],
-    "chartMode" : "single",
-    "chartType" : "line",
-    "chartconfig" : {
-      "absoluteEnd" : null,
-      "absoluteStart" : null,
-      "colorByMetric" : false,
-      "colorByValue" : false,
-      "colorByValueScale" : [ ],
-      "hideTimestamp" : false,
-      "histogramColor" : "#ea1849",
-      "maxDecimalPlaces" : 2,
-      "range" : -900000,
-      "rangeEnd" : null,
-      "secondaryVisualization" : "NONE",
-      "sortPreference" : "",
-      "useKMG2" : false,
-      "yAxisConfigurations" : [ {
-        "id" : "yAxis0",
-        "max" : null,
-        "min" : null,
-        "name" : "yAxis0",
-        "plotlines" : {
-          "high" : null,
-          "low" : null
-        }
-      } ]
-    },
-    "currentUniqueKey" : 3,
-    "revisionNumber" : 14,
-    "uiHelperValue" : "##CHARTID##_14"
-  }
-}, {
-  "marshallId" : 44,
-  "marshallMemberOf" : [ 42 ],
-  "sf_chart" : "Request Size",
-  "sf_chartIndex" : 1528146664212,
-  "sf_description" : "Average size of Service/API-fielded client request compared with -24h",
-  "sf_type" : "Chart",
-  "sf_uiModel" : {
-    "allPlots" : [ {
-      "_originalLabel" : "A",
-      "configuration" : {
-        "aliases" : { },
-        "colorOverride" : null,
-        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
-        "maxExtrapolations" : -1,
-        "prefix" : "",
-        "rollupPolicy" : null,
-        "suffix" : "",
-        "unitType" : "Byte",
-        "visualization" : null
-      },
-      "dataManipulations" : [ {
-        "direction" : {
-          "options" : {
-            "aggregateGroupBy" : [ {
-              "value" : "host"
-            } ],
-            "collapseGroups" : false,
-            "transformTimeRange" : null
-          },
-          "type" : "aggregation"
-        },
-        "fn" : {
-          "options" : { },
-          "type" : "SUM"
-        },
-        "showMe" : false
-      } ],
-      "invisible" : true,
-      "name" : "counter.kong.requests.size - Sum by host",
-      "queryItems" : [ {
-        "NOT" : false,
-        "iconClass" : "icon-properties",
-        "property" : "plugin",
-        "propertyValue" : "kong",
-        "type" : "property",
-        "value" : "kong"
-      } ],
-      "seriesData" : {
-        "metric" : "counter.kong.requests.size",
-        "regExStyle" : null
-      },
-      "transient" : false,
-      "type" : "plot",
-      "uniqueKey" : 1,
-      "yAxisIndex" : 0
-    }, {
-      "_originalLabel" : "B",
-      "configuration" : {
-        "aliases" : { },
-        "colorOverride" : null,
-        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
-        "maxExtrapolations" : -1,
-        "prefix" : "",
-        "rollupPolicy" : null,
-        "suffix" : "",
-        "unitType" : "Byte"
-      },
-      "dataManipulations" : [ {
-        "direction" : {
-          "options" : {
-            "aggregateGroupBy" : [ {
-              "value" : "host"
-            } ],
-            "collapseGroups" : false,
-            "transformTimeRange" : null
-          },
-          "type" : "aggregation"
-        },
-        "fn" : {
-          "options" : { },
-          "type" : "SUM"
-        },
-        "showMe" : false
-      } ],
-      "invisible" : true,
-      "name" : "counter.kong.responses.count - Sum by host",
-      "queryItems" : [ {
-        "NOT" : false,
-        "iconClass" : "icon-properties",
-        "property" : "plugin",
-        "propertyValue" : "kong",
-        "type" : "property",
-        "value" : "kong"
-      } ],
-      "seriesData" : {
-        "metric" : "counter.kong.responses.count",
-        "regExStyle" : null
-      },
-      "transient" : false,
-      "type" : "plot",
-      "uniqueKey" : 2,
-      "yAxisIndex" : 0
-    }, {
-      "_originalLabel" : "E",
-      "configuration" : {
-        "aliases" : { },
-        "colorOverride" : "#0dba8f",
-        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
-        "maxExtrapolations" : -1,
-        "prefix" : "",
-        "suffix" : "",
-        "unitType" : "Byte"
-      },
-      "dataManipulations" : [ ],
-      "expressionText" : "A/B",
-      "invisible" : false,
-      "metricDefinition" : { },
-      "name" : "request size",
-      "queryItems" : [ ],
-      "seriesData" : {
-        "metric" : null
-      },
-      "transient" : false,
-      "type" : "ratio",
-      "uniqueKey" : 5,
-      "valid" : true,
-      "yAxisIndex" : 0
-    }, {
-      "_originalLabel" : "J",
-      "configuration" : {
-        "aliases" : { },
-        "colorOverride" : "#b04600",
-        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
-        "maxExtrapolations" : -1,
-        "prefix" : "",
-        "suffix" : "",
-        "unitType" : "Byte",
-        "visualization" : "line"
-      },
-      "dataManipulations" : [ {
-        "direction" : {
-          "options" : {
-            "aggregateGroupBy" : [ ],
-            "collapseGroups" : false,
-            "transformTimeRange" : null
-          },
-          "type" : "aggregation"
-        },
-        "fn" : {
-          "options" : {
-            "milliseconds" : 86400000
-          },
-          "type" : "TIMESHIFT"
-        },
-        "showMe" : false
-      } ],
-      "expressionText" : "E",
-      "invisible" : false,
-      "metricDefinition" : { },
-      "name" : "request size (historic)",
-      "queryItems" : [ ],
-      "seriesData" : {
-        "metric" : null
-      },
-      "transient" : false,
-      "type" : "ratio",
-      "uniqueKey" : 10,
-      "valid" : true,
-      "yAxisIndex" : 1
-    }, {
-      "configuration" : {
-        "aliases" : { },
-        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
-        "maxExtrapolations" : -1
-      },
-      "dataManipulations" : [ ],
-      "invisible" : false,
-      "metricDefinition" : { },
-      "name" : "New Plot",
-      "queryItems" : [ ],
-      "seriesData" : { },
-      "transient" : true,
-      "type" : "plot",
-      "uniqueKey" : 11,
-      "yAxisIndex" : 0
-    } ],
-    "chartMode" : "graph",
-    "chartType" : "area",
-    "chartconfig" : {
-      "absoluteEnd" : null,
-      "absoluteStart" : null,
-      "eventLines" : false,
-      "histogramColor" : "#0077c2",
-      "range" : -900000,
-      "rangeEnd" : null,
-      "secondaryVisualization" : "NONE",
-      "sortPreference" : "",
-      "useKMG2" : false,
-      "yAxisConfigurations" : [ {
-        "id" : "yAxis0",
-        "label" : "bytes/req",
-        "max" : null,
-        "min" : null,
-        "name" : "yAxis0",
-        "plotlines" : {
-          "high" : null,
-          "low" : null
-        }
-      }, {
-        "label" : "bytes/req",
-        "max" : null,
-        "min" : null,
-        "plotlines" : {
-          "high" : null,
-          "low" : null
-        },
-        "title" : {
-          "text" : ""
-        }
-      } ]
-    },
-    "currentUniqueKey" : 12,
-    "relatedDetectors" : [ ],
-    "revisionNumber" : 26,
-    "uiHelperValue" : "##CHARTID##_26"
-  }
-}, {
-  "marshallId" : 45,
-  "marshallMemberOf" : [ 42 ],
-  "sf_chart" : "Requests / Second",
-  "sf_chartIndex" : 1528137043591,
-  "sf_description" : "Rate of total requests made to Kong",
-  "sf_type" : "Chart",
-  "sf_uiModel" : {
-    "allPlots" : [ {
-      "_originalLabel" : "A",
-      "configuration" : {
-        "aliases" : { },
-        "colorOverride" : null,
-        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
-        "maxExtrapolations" : -1,
-        "suffix" : "requests",
-        "unitType" : null
-      },
-      "dataManipulations" : [ {
-        "direction" : {
-          "options" : {
-            "aggregateGroupBy" : [ {
-              "value" : "host"
-            } ],
-            "collapseGroups" : false,
-            "transformTimeRange" : null
-          },
-          "type" : "aggregation"
-        },
-        "fn" : {
-          "options" : { },
-          "type" : "SUM"
-        },
-        "showMe" : false
-      } ],
-      "invisible" : false,
-      "name" : "total requests",
-      "queryItems" : [ {
-        "NOT" : false,
-        "iconClass" : "icon-properties",
-        "property" : "plugin",
-        "propertyValue" : "kong",
-        "type" : "property",
-        "value" : "kong"
-      } ],
-      "seriesData" : {
-        "metric" : "counter.kong.requests.count"
-      },
-      "transient" : false,
-      "type" : "plot",
-      "uniqueKey" : 1,
-      "yAxisIndex" : 0
-    }, {
-      "configuration" : {
-        "aliases" : { },
-        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
-        "maxExtrapolations" : -1
-      },
-      "dataManipulations" : [ ],
-      "invisible" : false,
-      "metricDefinition" : { },
-      "name" : "New Plot",
-      "queryItems" : [ ],
-      "seriesData" : { },
-      "transient" : true,
-      "type" : "plot",
-      "uniqueKey" : 3,
-      "yAxisIndex" : 0
-    } ],
-    "chartMode" : "graph",
-    "chartType" : "area",
-    "chartconfig" : {
-      "absoluteEnd" : null,
-      "absoluteStart" : null,
-      "histogramColor" : "#ea1849",
-      "range" : -900000,
-      "rangeEnd" : null,
-      "secondaryVisualization" : "NONE",
-      "sortPreference" : "",
-      "stackedChart" : true,
-      "useKMG2" : false,
-      "yAxisConfigurations" : [ {
-        "id" : "yAxis0",
-        "label" : "req/s",
-        "max" : null,
-        "min" : null,
-        "name" : "yAxis0",
-        "plotlines" : {
-          "high" : null,
-          "low" : null
-        }
-      } ]
-    },
-    "currentUniqueKey" : 4,
-    "revisionNumber" : 14,
-    "uiHelperValue" : "##CHARTID##_14"
-  }
-}, {
-  "marshallId" : 46,
-  "marshallMemberOf" : [ 42 ],
-  "sf_chart" : "Responses / Second",
-  "sf_chartIndex" : 1528219376990,
-  "sf_description" : "Rate of Service/API responses",
-  "sf_type" : "Chart",
-  "sf_uiModel" : {
-    "allPlots" : [ {
-      "_originalLabel" : "A",
-      "configuration" : {
-        "aliases" : { },
-        "colorOverride" : null,
-        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
-        "maxExtrapolations" : -1,
-        "prefix" : "",
-        "suffix" : "responses",
-        "unitType" : null
-      },
-      "dataManipulations" : [ {
-        "direction" : {
-          "options" : {
-            "aggregateGroupBy" : [ {
-              "value" : "host"
-            } ],
-            "collapseGroups" : false,
-            "transformTimeRange" : null
-          },
-          "type" : "aggregation"
-        },
-        "fn" : {
-          "options" : { },
-          "type" : "SUM"
-        },
-        "showMe" : false
-      } ],
-      "invisible" : false,
-      "name" : "upstream responses",
-      "queryItems" : [ {
-        "NOT" : false,
-        "iconClass" : "sf-icon-property",
-        "property" : "plugin",
-        "propertyValue" : "kong",
-        "query" : "plugin:\"kong\"",
-        "type" : "property",
-        "value" : "kong"
-      } ],
-      "seriesData" : {
-        "metric" : "counter.kong.responses.count"
-      },
-      "transient" : false,
-      "type" : "plot",
-      "uniqueKey" : 1,
-      "yAxisIndex" : 0
-    }, {
-      "configuration" : {
-        "aliases" : { },
-        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
-        "maxExtrapolations" : -1
-      },
-      "dataManipulations" : [ ],
-      "invisible" : false,
-      "metricDefinition" : { },
-      "name" : "New Plot",
-      "queryItems" : [ ],
-      "seriesData" : { },
-      "transient" : true,
-      "type" : "plot",
-      "uniqueKey" : 2,
-      "yAxisIndex" : 0
-    } ],
-    "chartMode" : "graph",
-    "chartType" : "area",
-    "chartconfig" : {
-      "absoluteEnd" : null,
-      "absoluteStart" : null,
-      "colorByMetric" : false,
-      "colorByValue" : false,
-      "colorByValueScale" : [ ],
-      "hideTimestamp" : false,
-      "histogramColor" : "#ea1849",
-      "maxDecimalPlaces" : 2,
-      "range" : -3600000,
-      "rangeEnd" : 0,
-      "secondaryVisualization" : "NONE",
-      "sortPreference" : "",
-      "stackedChart" : true,
-      "useKMG2" : false,
-      "yAxisConfigurations" : [ {
-        "id" : "yAxis0",
-        "label" : "resp/s",
-        "max" : null,
-        "min" : null,
-        "name" : "yAxis0",
-        "plotlines" : {
-          "high" : null,
-          "low" : null
-        }
-      } ]
-    },
-    "currentUniqueKey" : 3,
-    "relatedDetectors" : [ ],
-    "revisionNumber" : 23,
-    "uiHelperValue" : "##CHARTID##_23"
-  }
-}, {
-  "marshallId" : 47,
-  "marshallMemberOf" : [ 42 ],
-  "sf_chart" : "Upstream Latency",
-  "sf_chartIndex" : 1528135368079,
-  "sf_description" : "Average latency for responses from upstream groups compared with -24h",
-  "sf_type" : "Chart",
-  "sf_uiModel" : {
-    "allPlots" : [ {
-      "_originalLabel" : "A",
-      "configuration" : {
-        "aliases" : { },
-        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
-        "maxExtrapolations" : -1,
-        "prefix" : "",
-        "rollupPolicy" : "LATEST_ROLLUP",
-        "suffix" : "",
-        "unitType" : "Millisecond"
-      },
-      "dataManipulations" : [ {
-        "direction" : {
-          "options" : {
-            "aggregateGroupBy" : [ {
-              "value" : "host"
-            } ],
-            "collapseGroups" : false,
-            "transformTimeRange" : null
-          },
-          "type" : "aggregation"
-        },
-        "fn" : {
-          "options" : { },
-          "type" : "SUM"
-        },
-        "showMe" : false
-      } ],
-      "invisible" : true,
-      "name" : "counter.kong.upstream.latency - Sum by host",
-      "queryItems" : [ {
-        "NOT" : false,
-        "iconClass" : "icon-properties",
-        "property" : "plugin",
-        "propertyValue" : "kong",
-        "type" : "property",
-        "value" : "kong"
-      } ],
-      "seriesData" : {
-        "metric" : "counter.kong.upstream.latency",
-        "regExStyle" : null
-      },
-      "transient" : false,
-      "type" : "plot",
-      "uniqueKey" : 1,
-      "yAxisIndex" : 0
-    }, {
-      "_originalLabel" : "D",
-      "configuration" : {
-        "aliases" : { },
-        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
-        "maxExtrapolations" : -1,
-        "rollupPolicy" : "LATEST_ROLLUP"
-      },
-      "dataManipulations" : [ {
-        "direction" : {
-          "options" : {
-            "aggregateGroupBy" : [ {
-              "value" : "host"
-            } ],
-            "collapseGroups" : false,
-            "transformTimeRange" : null
-          },
-          "type" : "aggregation"
-        },
-        "fn" : {
-          "options" : { },
-          "type" : "SUM"
-        },
-        "showMe" : false
-      } ],
-      "invisible" : true,
-      "metricDefinition" : { },
-      "name" : "counter.kong.responses.count - Sum by host",
-      "queryItems" : [ {
-        "NOT" : false,
-        "iconClass" : "icon-properties",
-        "property" : "plugin",
-        "propertyValue" : "kong",
-        "type" : "property",
-        "value" : "kong"
-      } ],
-      "seriesData" : {
-        "metric" : "counter.kong.responses.count",
-        "regExStyle" : null
-      },
-      "transient" : false,
-      "type" : "plot",
-      "uniqueKey" : 4,
-      "yAxisIndex" : 0
-    }, {
-      "_originalLabel" : "E",
-      "configuration" : {
-        "aliases" : { },
-        "colorOverride" : "#a747ff",
-        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
-        "maxExtrapolations" : -1,
-        "prefix" : "",
-        "suffix" : "",
-        "unitType" : "Millisecond"
-      },
-      "dataManipulations" : [ ],
-      "expressionText" : "A / D",
-      "invisible" : false,
-      "metricDefinition" : { },
-      "name" : "latency",
-      "queryItems" : [ ],
-      "seriesData" : {
-        "metric" : null
-      },
-      "transient" : false,
-      "type" : "ratio",
-      "uniqueKey" : 5,
-      "valid" : true,
-      "yAxisIndex" : 0
-    }, {
-      "_originalLabel" : "I",
-      "configuration" : {
-        "aliases" : { },
-        "colorOverride" : "#b04600",
-        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
-        "maxExtrapolations" : -1,
-        "prefix" : "",
-        "suffix" : "",
-        "unitType" : "Millisecond",
-        "visualization" : "line"
-      },
-      "dataManipulations" : [ {
-        "direction" : {
-          "options" : {
-            "aggregateGroupBy" : [ ],
-            "collapseGroups" : false,
-            "transformTimeRange" : null
-          },
-          "type" : "aggregation"
-        },
-        "fn" : {
-          "options" : {
-            "milliseconds" : 86400000
-          },
-          "type" : "TIMESHIFT"
-        },
-        "showMe" : false
-      } ],
-      "expressionText" : "E",
-      "invisible" : false,
-      "metricDefinition" : { },
-      "name" : "latency (historic)",
-      "queryItems" : [ ],
-      "seriesData" : {
-        "metric" : null
-      },
-      "transient" : false,
-      "type" : "ratio",
-      "uniqueKey" : 9,
-      "valid" : true,
-      "yAxisIndex" : 1
-    }, {
-      "configuration" : {
-        "aliases" : { },
-        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
-        "maxExtrapolations" : -1
-      },
-      "dataManipulations" : [ ],
-      "invisible" : false,
-      "metricDefinition" : { },
-      "name" : "New Plot",
-      "queryItems" : [ ],
-      "seriesData" : { },
-      "transient" : true,
-      "type" : "plot",
-      "uniqueKey" : 10,
-      "yAxisIndex" : 0
-    } ],
-    "chartMode" : "graph",
-    "chartType" : "area",
-    "chartconfig" : {
-      "absoluteEnd" : null,
-      "absoluteStart" : null,
-      "histogramColor" : "#ea1849",
-      "range" : -900000,
-      "rangeEnd" : null,
-      "secondaryVisualization" : "NONE",
-      "sortPreference" : "",
-      "useKMG2" : false,
-      "yAxisConfigurations" : [ {
-        "id" : "yAxis0",
-        "label" : "latency/resp",
-        "max" : null,
-        "min" : null,
-        "name" : "yAxis0",
-        "plotlines" : {
-          "high" : null,
-          "low" : null
-        }
-      }, {
-        "label" : "latency/resp",
-        "max" : null,
-        "min" : null,
-        "plotlines" : {
-          "high" : null,
-          "low" : null
-        },
-        "title" : {
-          "text" : ""
-        }
-      } ]
-    },
-    "currentUniqueKey" : 11,
-    "revisionNumber" : 25,
-    "uiHelperValue" : "##CHARTID##_25"
-  }
-}, {
-  "marshallId" : 48,
-  "marshallMemberOf" : [ 42 ],
-  "sf_chart" : "Response Size",
-  "sf_chartIndex" : 1528139299895,
-  "sf_description" : "Average size of response from Service/API compared with -24h",
-  "sf_type" : "Chart",
-  "sf_uiModel" : {
-    "allPlots" : [ {
-      "_originalLabel" : "A",
-      "configuration" : {
-        "aliases" : { },
-        "colorOverride" : null,
-        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
-        "maxExtrapolations" : -1,
-        "prefix" : "",
-        "rollupPolicy" : null,
-        "suffix" : "",
-        "unitType" : "Byte",
-        "visualization" : null
-      },
-      "dataManipulations" : [ {
-        "direction" : {
-          "options" : {
-            "aggregateGroupBy" : [ {
-              "value" : "host"
-            } ],
-            "collapseGroups" : false,
-            "transformTimeRange" : null
-          },
-          "type" : "aggregation"
-        },
-        "fn" : {
-          "options" : { },
-          "type" : "SUM"
-        },
-        "showMe" : false
-      } ],
-      "invisible" : true,
-      "name" : "counter.kong.responses.size - Sum by host",
-      "queryItems" : [ {
-        "NOT" : false,
-        "iconClass" : "icon-properties",
-        "property" : "plugin",
-        "propertyValue" : "kong",
-        "type" : "property",
-        "value" : "kong"
-      } ],
-      "seriesData" : {
-        "metric" : "counter.kong.responses.size",
-        "regExStyle" : null
-      },
-      "transient" : false,
-      "type" : "plot",
-      "uniqueKey" : 1,
-      "yAxisIndex" : 0
-    }, {
-      "_originalLabel" : "C",
-      "configuration" : {
-        "aliases" : { },
-        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
-        "maxExtrapolations" : -1,
-        "rollupPolicy" : null
-      },
-      "dataManipulations" : [ {
-        "direction" : {
-          "options" : {
-            "aggregateGroupBy" : [ {
-              "value" : "host"
-            } ],
-            "collapseGroups" : false,
-            "transformTimeRange" : null
-          },
-          "type" : "aggregation"
-        },
-        "fn" : {
-          "options" : { },
-          "type" : "SUM"
-        },
-        "showMe" : false
-      } ],
-      "invisible" : true,
-      "metricDefinition" : { },
-      "name" : "counter.kong.responses.count - Sum by host",
-      "queryItems" : [ {
-        "NOT" : false,
-        "iconClass" : "icon-properties",
-        "property" : "plugin",
-        "propertyValue" : "kong",
-        "type" : "property",
-        "value" : "kong"
-      } ],
-      "seriesData" : {
-        "metric" : "counter.kong.responses.count",
-        "regExStyle" : null
-      },
-      "transient" : false,
-      "type" : "plot",
-      "uniqueKey" : 3,
-      "yAxisIndex" : 0
-    }, {
-      "_originalLabel" : "E",
-      "configuration" : {
-        "aliases" : { },
-        "colorOverride" : "#6ca2b7",
-        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
-        "maxExtrapolations" : -1,
-        "prefix" : "",
-        "suffix" : "",
-        "unitType" : "Byte"
-      },
-      "dataManipulations" : [ ],
-      "expressionText" : "A/C",
-      "invisible" : false,
-      "metricDefinition" : { },
-      "name" : "response size",
-      "queryItems" : [ ],
-      "seriesData" : {
-        "metric" : null
-      },
-      "transient" : false,
-      "type" : "ratio",
-      "uniqueKey" : 5,
-      "valid" : true,
-      "yAxisIndex" : 0
-    }, {
-      "_originalLabel" : "J",
-      "configuration" : {
-        "aliases" : { },
-        "colorOverride" : "#b04600",
-        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
-        "maxExtrapolations" : -1,
-        "prefix" : "",
-        "suffix" : "",
-        "unitType" : "Byte",
-        "visualization" : "line"
-      },
-      "dataManipulations" : [ {
-        "direction" : {
-          "options" : {
-            "aggregateGroupBy" : [ ],
-            "collapseGroups" : false,
-            "transformTimeRange" : null
-          },
-          "type" : "aggregation"
-        },
-        "fn" : {
-          "options" : {
-            "milliseconds" : 86400000
-          },
-          "type" : "TIMESHIFT"
-        },
-        "showMe" : false
-      } ],
-      "expressionText" : "E",
-      "invisible" : false,
-      "metricDefinition" : { },
-      "name" : "response size (historic)",
-      "queryItems" : [ ],
-      "seriesData" : {
-        "metric" : null
-      },
-      "transient" : false,
-      "type" : "ratio",
-      "uniqueKey" : 10,
-      "valid" : true,
-      "yAxisIndex" : 1
-    }, {
-      "configuration" : {
-        "aliases" : { },
-        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
-        "maxExtrapolations" : -1
-      },
-      "dataManipulations" : [ ],
-      "invisible" : false,
-      "metricDefinition" : { },
-      "name" : "New Plot",
-      "queryItems" : [ ],
-      "seriesData" : { },
-      "transient" : true,
-      "type" : "plot",
-      "uniqueKey" : 11,
-      "yAxisIndex" : 0
-    } ],
-    "chartMode" : "graph",
-    "chartType" : "area",
-    "chartconfig" : {
-      "absoluteEnd" : null,
-      "absoluteStart" : null,
-      "histogramColor" : "#ea1849",
-      "legendColumnConfiguration" : null,
-      "range" : -900000,
-      "rangeEnd" : null,
-      "secondaryVisualization" : "NONE",
-      "sortPreference" : "",
-      "useKMG2" : false,
-      "yAxisConfigurations" : [ {
-        "id" : "yAxis0",
-        "label" : "bytes/req",
-        "max" : null,
-        "min" : null,
-        "name" : "yAxis0",
-        "plotlines" : {
-          "high" : null,
-          "low" : null
-        }
-      }, {
-        "label" : "bytes/req",
-        "max" : null,
-        "min" : null,
-        "plotlines" : {
-          "high" : null,
-          "low" : null
-        },
-        "title" : {
-          "text" : ""
-        }
-      } ]
-    },
-    "currentUniqueKey" : 12,
-    "revisionNumber" : 26,
-    "uiHelperValue" : "##CHARTID##_26"
-  }
-}, {
-  "marshallId" : 49,
-  "marshallMemberOf" : [ 42 ],
+  "marshallId" : 52,
+  "marshallMemberOf" : [ 43 ],
   "sf_chart" : "Requests / Second",
   "sf_chartIndex" : 1528227295288,
   "sf_description" : "Rate of total requests made to Kong",
@@ -10560,7 +10690,7 @@
       "hideTimestamp" : false,
       "histogramColor" : "#ea1849",
       "maxDecimalPlaces" : 2,
-      "range" : -3600000,
+      "range" : -1800000,
       "rangeEnd" : 0,
       "secondaryVisualization" : "NONE",
       "sortPreference" : "",
@@ -10583,11 +10713,11 @@
     "uiHelperValue" : "##CHARTID##_16"
   }
 }, {
-  "marshallId" : 50,
-  "marshallMemberOf" : [ 42 ],
-  "sf_chart" : "Requests by HTTP Method",
-  "sf_chartIndex" : 1528138165800,
-  "sf_description" : "Rate of Service/API-fielded requests by HTTP Method",
+  "marshallId" : 53,
+  "marshallMemberOf" : [ 43 ],
+  "sf_chart" : "Response Size",
+  "sf_chartIndex" : 1528139299895,
+  "sf_description" : "5 largest average sizes of responses from upstream groups by Service/API compared with -24h overall average",
   "sf_type" : "Chart",
   "sf_uiModel" : {
     "allPlots" : [ {
@@ -10597,114 +10727,17 @@
         "colorOverride" : null,
         "extrapolationPolicy" : "NULL_EXTRAPOLATION",
         "maxExtrapolations" : -1,
-        "suffix" : "req/s",
-        "unitType" : null
-      },
-      "dataManipulations" : [ {
-        "direction" : {
-          "options" : {
-            "aggregateGroupBy" : [ {
-              "value" : "http_method"
-            } ],
-            "collapseGroups" : false,
-            "transformTimeRange" : null
-          },
-          "type" : "aggregation"
-        },
-        "fn" : {
-          "options" : { },
-          "type" : "SUM"
-        },
-        "showMe" : false
-      } ],
-      "invisible" : false,
-      "name" : "",
-      "queryItems" : [ {
-        "NOT" : false,
-        "iconClass" : "icon-properties",
-        "property" : "plugin",
-        "propertyValue" : "kong",
-        "type" : "property",
-        "value" : "kong"
-      } ],
-      "seriesData" : {
-        "metric" : "counter.kong.responses.count"
-      },
-      "transient" : false,
-      "type" : "plot",
-      "uniqueKey" : 1,
-      "yAxisIndex" : 0
-    }, {
-      "configuration" : {
-        "aliases" : { },
-        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
-        "maxExtrapolations" : -1
-      },
-      "dataManipulations" : [ ],
-      "invisible" : false,
-      "metricDefinition" : { },
-      "name" : "New Plot",
-      "queryItems" : [ ],
-      "seriesData" : { },
-      "transient" : true,
-      "type" : "plot",
-      "uniqueKey" : 18,
-      "yAxisIndex" : 0
-    } ],
-    "chartMode" : "list",
-    "chartType" : "line",
-    "chartconfig" : {
-      "absoluteEnd" : null,
-      "absoluteStart" : null,
-      "colorByMetric" : false,
-      "colorByValue" : false,
-      "colorByValueScale" : [ ],
-      "histogramColor" : "#ea1849",
-      "maxDecimalPlaces" : 4,
-      "range" : -900000,
-      "rangeEnd" : null,
-      "secondaryVisualization" : "SPARKLINE",
-      "sortPreference" : "+http_method",
-      "useKMG2" : false,
-      "yAxisConfigurations" : [ {
-        "id" : "yAxis0",
-        "max" : null,
-        "min" : null,
-        "name" : "yAxis0",
-        "plotlines" : {
-          "high" : null,
-          "low" : null
-        }
-      } ]
-    },
-    "currentUniqueKey" : 19,
-    "revisionNumber" : 18,
-    "uiHelperValue" : "##CHARTID##_18"
-  }
-}, {
-  "marshallId" : 51,
-  "marshallMemberOf" : [ 42 ],
-  "sf_chart" : "Kong Latency",
-  "sf_chartIndex" : 1528147046843,
-  "sf_description" : "Average Kong-induced latency for requests compared with -24h",
-  "sf_type" : "Chart",
-  "sf_uiModel" : {
-    "allPlots" : [ {
-      "_originalLabel" : "A",
-      "configuration" : {
-        "aliases" : { },
-        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
-        "maxExtrapolations" : -1,
         "prefix" : "",
-        "rollupPolicy" : "LATEST_ROLLUP",
+        "rollupPolicy" : null,
         "suffix" : "",
-        "unitType" : "Millisecond"
+        "unitType" : "Byte",
+        "visualization" : null
       },
       "dataManipulations" : [ {
         "direction" : {
           "options" : {
             "aggregateGroupBy" : [ {
-              "value" : "host"
+              "value" : "service_name"
             } ],
             "collapseGroups" : false,
             "transformTimeRange" : null
@@ -10718,7 +10751,7 @@
         "showMe" : false
       } ],
       "invisible" : true,
-      "name" : "counter.kong.kong.latency - Sum by host",
+      "name" : "counter.kong.responses.size - Sum by service_name",
       "queryItems" : [ {
         "NOT" : false,
         "iconClass" : "icon-properties",
@@ -10728,7 +10761,7 @@
         "value" : "kong"
       } ],
       "seriesData" : {
-        "metric" : "counter.kong.kong.latency",
+        "metric" : "counter.kong.responses.size",
         "regExStyle" : null
       },
       "transient" : false,
@@ -10736,18 +10769,66 @@
       "uniqueKey" : 1,
       "yAxisIndex" : 0
     }, {
-      "_originalLabel" : "D",
+      "_originalLabel" : "K",
       "configuration" : {
         "aliases" : { },
+        "colorOverride" : null,
         "extrapolationPolicy" : "NULL_EXTRAPOLATION",
         "maxExtrapolations" : -1,
-        "rollupPolicy" : "LATEST_ROLLUP"
+        "prefix" : "",
+        "rollupPolicy" : null,
+        "suffix" : "",
+        "unitType" : "Byte",
+        "visualization" : null
       },
       "dataManipulations" : [ {
         "direction" : {
           "options" : {
             "aggregateGroupBy" : [ {
-              "value" : "host"
+              "value" : "api_name"
+            } ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          },
+          "type" : "aggregation"
+        },
+        "fn" : {
+          "options" : { },
+          "type" : "SUM"
+        },
+        "showMe" : false
+      } ],
+      "invisible" : true,
+      "name" : "counter.kong.responses.size - Sum by api_name",
+      "queryItems" : [ {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "plugin",
+        "propertyValue" : "kong",
+        "type" : "property",
+        "value" : "kong"
+      } ],
+      "seriesData" : {
+        "metric" : "counter.kong.responses.size",
+        "regExStyle" : null
+      },
+      "transient" : false,
+      "type" : "plot",
+      "uniqueKey" : 11,
+      "yAxisIndex" : 0
+    }, {
+      "_originalLabel" : "C",
+      "configuration" : {
+        "aliases" : { },
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
+        "maxExtrapolations" : -1,
+        "rollupPolicy" : null
+      },
+      "dataManipulations" : [ {
+        "direction" : {
+          "options" : {
+            "aggregateGroupBy" : [ {
+              "value" : "service_name"
             } ],
             "collapseGroups" : false,
             "transformTimeRange" : null
@@ -10762,7 +10843,7 @@
       } ],
       "invisible" : true,
       "metricDefinition" : { },
-      "name" : "counter.kong.responses.count - Sum by host",
+      "name" : "counter.kong.responses.count - Sum by service_name",
       "queryItems" : [ {
         "NOT" : false,
         "iconClass" : "icon-properties",
@@ -10777,44 +10858,62 @@
       },
       "transient" : false,
       "type" : "plot",
-      "uniqueKey" : 4,
+      "uniqueKey" : 3,
       "yAxisIndex" : 0
     }, {
-      "_originalLabel" : "E",
+      "_originalLabel" : "L",
       "configuration" : {
         "aliases" : { },
-        "colorOverride" : "#ab99bc",
         "extrapolationPolicy" : "NULL_EXTRAPOLATION",
         "maxExtrapolations" : -1,
-        "prefix" : "",
-        "suffix" : "",
-        "unitType" : "Millisecond"
+        "rollupPolicy" : null
       },
-      "dataManipulations" : [ ],
-      "expressionText" : "A / D",
-      "invisible" : false,
+      "dataManipulations" : [ {
+        "direction" : {
+          "options" : {
+            "aggregateGroupBy" : [ {
+              "value" : "api_name"
+            } ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          },
+          "type" : "aggregation"
+        },
+        "fn" : {
+          "options" : { },
+          "type" : "SUM"
+        },
+        "showMe" : false
+      } ],
+      "invisible" : true,
       "metricDefinition" : { },
-      "name" : "latency",
-      "queryItems" : [ ],
+      "name" : "counter.kong.responses.count - Sum by api_name",
+      "queryItems" : [ {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "plugin",
+        "propertyValue" : "kong",
+        "type" : "property",
+        "value" : "kong"
+      } ],
       "seriesData" : {
-        "metric" : null
+        "metric" : "counter.kong.responses.count",
+        "regExStyle" : null
       },
       "transient" : false,
-      "type" : "ratio",
-      "uniqueKey" : 5,
-      "valid" : true,
+      "type" : "plot",
+      "uniqueKey" : 12,
       "yAxisIndex" : 0
     }, {
-      "_originalLabel" : "I",
+      "_originalLabel" : "M",
       "configuration" : {
         "aliases" : { },
-        "colorOverride" : "#b04600",
+        "colorOverride" : null,
         "extrapolationPolicy" : "NULL_EXTRAPOLATION",
         "maxExtrapolations" : -1,
         "prefix" : "",
         "suffix" : "",
-        "unitType" : "Millisecond",
-        "visualization" : "line"
+        "unitType" : "Byte"
       },
       "dataManipulations" : [ {
         "direction" : {
@@ -10827,103 +10926,145 @@
         },
         "fn" : {
           "options" : {
-            "milliseconds" : 86400000
+            "count" : 5
           },
-          "type" : "TIMESHIFT"
+          "type" : "TOPN"
         },
         "showMe" : false
       } ],
-      "expressionText" : "E",
+      "expressionText" : "A/C",
       "invisible" : false,
       "metricDefinition" : { },
-      "name" : "latency (historic)",
+      "name" : "response size (service)",
       "queryItems" : [ ],
       "seriesData" : {
         "metric" : null
       },
       "transient" : false,
       "type" : "ratio",
-      "uniqueKey" : 9,
+      "uniqueKey" : 13,
       "valid" : true,
-      "yAxisIndex" : 1
+      "yAxisIndex" : 0
     }, {
+      "_originalLabel" : "O",
+      "configuration" : {
+        "aliases" : { },
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
+        "maxExtrapolations" : -1,
+        "prefix" : "",
+        "suffix" : "",
+        "unitType" : "Byte"
+      },
+      "dataManipulations" : [ {
+        "direction" : {
+          "options" : {
+            "aggregateGroupBy" : [ ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          },
+          "type" : "aggregation"
+        },
+        "fn" : {
+          "options" : {
+            "count" : 5
+          },
+          "type" : "TOPN"
+        },
+        "showMe" : false
+      } ],
+      "expressionText" : "K/L",
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "response size (api)",
+      "queryItems" : [ ],
+      "seriesData" : {
+        "metric" : null
+      },
+      "transient" : false,
+      "type" : "ratio",
+      "uniqueKey" : 15,
+      "valid" : true,
+      "yAxisIndex" : 0
+    }, {
+      "_originalLabel" : "P",
       "configuration" : {
         "aliases" : { },
         "extrapolationPolicy" : "NULL_EXTRAPOLATION",
         "maxExtrapolations" : -1
       },
-      "dataManipulations" : [ ],
-      "invisible" : false,
-      "metricDefinition" : { },
-      "name" : "New Plot",
-      "queryItems" : [ ],
-      "seriesData" : { },
-      "transient" : true,
-      "type" : "plot",
-      "uniqueKey" : 10,
-      "yAxisIndex" : 0
-    } ],
-    "chartMode" : "graph",
-    "chartType" : "area",
-    "chartconfig" : {
-      "absoluteEnd" : null,
-      "absoluteStart" : null,
-      "groupBy" : [ ],
-      "heatmapAutoGradients" : 5,
-      "heatmapColorRange" : { },
-      "heatmapSortBy" : {
-        "asc" : true,
-        "value" : { }
-      },
-      "heatmapUnitsPerRow" : 0,
-      "heatmapUseValueAsColor" : false,
-      "hideTimestamp" : false,
-      "histogramColor" : "#ea1849",
-      "range" : -900000,
-      "rangeEnd" : null,
-      "secondaryVisualization" : "NONE",
-      "sortPreference" : "",
-      "useKMG2" : false,
-      "yAxisConfigurations" : [ {
-        "id" : "yAxis0",
-        "label" : "latency/req",
-        "max" : null,
-        "min" : null,
-        "name" : "yAxis0",
-        "plotlines" : {
-          "high" : null,
-          "low" : null
-        }
-      }, {
-        "label" : "latency/req",
-        "max" : null,
-        "min" : null,
-        "plotlines" : {
-          "high" : null,
-          "low" : null
+      "dataManipulations" : [ {
+        "direction" : {
+          "options" : {
+            "aggregateGroupBy" : [ ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          },
+          "type" : "aggregation"
         },
-        "title" : {
-          "text" : ""
-        }
-      } ]
-    },
-    "currentUniqueKey" : 11,
-    "relatedDetectors" : [ ],
-    "revisionNumber" : 22,
-    "uiHelperValue" : "##CHARTID##_22"
-  }
-}, {
-  "marshallId" : 52,
-  "marshallMemberOf" : [ 42 ],
-  "sf_chart" : "Bytes Out / Second",
-  "sf_chartIndex" : 1528310523139,
-  "sf_description" : "Service/API response transfer rate compared with -24h",
-  "sf_type" : "Chart",
-  "sf_uiModel" : {
-    "allPlots" : [ {
-      "_originalLabel" : "A",
+        "fn" : {
+          "options" : { },
+          "type" : "SUM"
+        },
+        "showMe" : false
+      } ],
+      "expressionText" : "A",
+      "invisible" : true,
+      "metricDefinition" : { },
+      "name" : "A - Sum",
+      "queryItems" : [ ],
+      "seriesData" : {
+        "metric" : null
+      },
+      "transient" : false,
+      "type" : "ratio",
+      "uniqueKey" : 16,
+      "valid" : true,
+      "yAxisIndex" : 0
+    }, {
+      "_originalLabel" : "Q",
       "configuration" : {
         "aliases" : { },
+        "colorOverride" : null,
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
+        "maxExtrapolations" : -1,
+        "prefix" : "",
+        "suffix" : "",
+        "unitType" : "Byte",
+        "visualization" : null
+      },
+      "dataManipulations" : [ {
+        "direction" : {
+          "options" : {
+            "aggregateGroupBy" : [ ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          },
+          "type" : "aggregation"
+        },
+        "fn" : {
+          "options" : { },
+          "type" : "SUM"
+        },
+        "showMe" : false
+      } ],
+      "expressionText" : "C",
+      "invisible" : true,
+      "metricDefinition" : { },
+      "name" : "C - Sum",
+      "queryItems" : [ ],
+      "seriesData" : {
+        "metric" : null
+      },
+      "transient" : false,
+      "type" : "ratio",
+      "uniqueKey" : 17,
+      "valid" : true,
+      "yAxisIndex" : 0
+    }, {
+      "_originalLabel" : "R",
+      "configuration" : {
+        "aliases" : { },
+        "colorOverride" : null,
         "extrapolationPolicy" : "NULL_EXTRAPOLATION",
         "maxExtrapolations" : -1,
         "prefix" : "",
@@ -10945,8 +11086,204 @@
         },
         "showMe" : false
       } ],
+      "expressionText" : "K",
+      "invisible" : true,
+      "metricDefinition" : { },
+      "name" : "",
+      "queryItems" : [ ],
+      "seriesData" : {
+        "metric" : null
+      },
+      "transient" : false,
+      "type" : "ratio",
+      "uniqueKey" : 18,
+      "valid" : true,
+      "yAxisIndex" : 0
+    }, {
+      "_originalLabel" : "S",
+      "configuration" : {
+        "aliases" : { },
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
+        "maxExtrapolations" : -1
+      },
+      "dataManipulations" : [ {
+        "direction" : {
+          "options" : {
+            "aggregateGroupBy" : [ ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          },
+          "type" : "aggregation"
+        },
+        "fn" : {
+          "options" : { },
+          "type" : "SUM"
+        },
+        "showMe" : false
+      } ],
+      "expressionText" : "L",
+      "invisible" : true,
+      "metricDefinition" : { },
+      "name" : "L - Sum",
+      "queryItems" : [ ],
+      "seriesData" : {
+        "metric" : null
+      },
+      "transient" : false,
+      "type" : "ratio",
+      "uniqueKey" : 19,
+      "valid" : true,
+      "yAxisIndex" : 0
+    }, {
+      "_originalLabel" : "V",
+      "configuration" : {
+        "aliases" : { },
+        "colorOverride" : null,
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
+        "maxExtrapolations" : -1,
+        "prefix" : "",
+        "suffix" : "",
+        "unitType" : "Byte",
+        "visualization" : "line"
+      },
+      "dataManipulations" : [ {
+        "direction" : {
+          "options" : {
+            "aggregateGroupBy" : [ ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          },
+          "type" : "aggregation"
+        },
+        "fn" : {
+          "options" : {
+            "milliseconds" : 86400000
+          },
+          "type" : "TIMESHIFT"
+        },
+        "showMe" : false
+      } ],
+      "expressionText" : "(P+R)/(Q+S)",
       "invisible" : false,
-      "name" : "responses",
+      "metricDefinition" : { },
+      "name" : "response size (historic)",
+      "queryItems" : [ ],
+      "seriesData" : {
+        "metric" : null
+      },
+      "transient" : false,
+      "type" : "ratio",
+      "uniqueKey" : 22,
+      "valid" : true,
+      "yAxisIndex" : 1
+    }, {
+      "configuration" : {
+        "aliases" : { },
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
+        "maxExtrapolations" : -1
+      },
+      "dataManipulations" : [ ],
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "New Plot",
+      "queryItems" : [ ],
+      "seriesData" : { },
+      "transient" : true,
+      "type" : "plot",
+      "uniqueKey" : 23,
+      "yAxisIndex" : 0
+    } ],
+    "chartMode" : "list",
+    "chartType" : "line",
+    "chartconfig" : {
+      "absoluteEnd" : null,
+      "absoluteStart" : null,
+      "colorByMetric" : false,
+      "colorByValue" : false,
+      "colorByValueScale" : [ ],
+      "groupBy" : [ ],
+      "heatmapAutoGradients" : 5,
+      "heatmapColorRange" : { },
+      "heatmapSortBy" : {
+        "asc" : true,
+        "value" : { }
+      },
+      "heatmapUnitsPerRow" : 0,
+      "heatmapUseValueAsColor" : false,
+      "hideTimestamp" : false,
+      "histogramColor" : "#0077c2",
+      "legendColumnConfiguration" : null,
+      "range" : -900000,
+      "rangeEnd" : null,
+      "secondaryVisualization" : "SPARKLINE",
+      "sortPreference" : "-value",
+      "stackedChart" : false,
+      "useKMG2" : false,
+      "yAxisConfigurations" : [ {
+        "id" : "yAxis0",
+        "label" : "bytes/req",
+        "max" : null,
+        "min" : null,
+        "name" : "yAxis0",
+        "plotlines" : {
+          "high" : null,
+          "low" : null
+        }
+      }, {
+        "label" : "bytes/req",
+        "max" : null,
+        "min" : null,
+        "plotlines" : {
+          "high" : null,
+          "low" : null
+        },
+        "title" : {
+          "text" : ""
+        }
+      } ]
+    },
+    "currentUniqueKey" : 24,
+    "relatedDetectors" : [ ],
+    "revisionNumber" : 33,
+    "uiHelperValue" : "##CHARTID##_33"
+  }
+}, {
+  "marshallId" : 54,
+  "marshallMemberOf" : [ 43 ],
+  "sf_chart" : "Database Reachable",
+  "sf_chartIndex" : 1528137157576,
+  "sf_description" : "Connection status as reported by kong.dao",
+  "sf_type" : "Chart",
+  "sf_uiModel" : {
+    "allPlots" : [ {
+      "_originalLabel" : "A",
+      "configuration" : {
+        "aliases" : { },
+        "extrapolationPolicy" : "LAST_VALUE_EXTRAPOLATION",
+        "maxExtrapolations" : -1,
+        "prefix" : "",
+        "suffix" : "",
+        "unitType" : null
+      },
+      "dataManipulations" : [ {
+        "direction" : {
+          "options" : {
+            "aggregateGroupBy" : [ {
+              "value" : "host"
+            } ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          },
+          "type" : "aggregation"
+        },
+        "fn" : {
+          "options" : { },
+          "type" : "COUNT"
+        },
+        "showMe" : false
+      } ],
+      "invisible" : false,
+      "name" : "is reachable",
       "queryItems" : [ {
         "NOT" : false,
         "iconClass" : "icon-properties",
@@ -10956,7 +11293,126 @@
         "value" : "kong"
       } ],
       "seriesData" : {
-        "metric" : "counter.kong.responses.size"
+        "metric" : "gauge.kong.database.reachable"
+      },
+      "transient" : false,
+      "type" : "plot",
+      "uniqueKey" : 1,
+      "yAxisIndex" : 0
+    }, {
+      "configuration" : {
+        "aliases" : { },
+        "extrapolationPolicy" : "LAST_VALUE_EXTRAPOLATION",
+        "maxExtrapolations" : -1
+      },
+      "dataManipulations" : [ ],
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "New Plot",
+      "queryItems" : [ ],
+      "seriesData" : { },
+      "transient" : true,
+      "type" : "plot",
+      "uniqueKey" : 2,
+      "yAxisIndex" : 0
+    } ],
+    "chartMode" : "heatmap",
+    "chartType" : null,
+    "chartconfig" : {
+      "absoluteEnd" : null,
+      "absoluteStart" : null,
+      "colorByMetric" : false,
+      "colorByValue" : true,
+      "colorByValueScale" : [ {
+        "color" : "#6bd37e",
+        "gte" : 1
+      }, {
+        "color" : "#ea1849",
+        "lt" : 1
+      } ],
+      "groupBy" : [ ],
+      "heatmapAutoGradients" : 5,
+      "heatmapColorOverride" : "#05ce00",
+      "heatmapColorRange" : {
+        "max" : 1,
+        "min" : 0
+      },
+      "heatmapSortBy" : {
+        "asc" : true,
+        "value" : { }
+      },
+      "heatmapUnitsPerRow" : 0,
+      "heatmapUseValueAsColor" : false,
+      "hideTimestamp" : false,
+      "histogramColor" : "#ea1849",
+      "range" : -1800000,
+      "rangeEnd" : 0,
+      "secondaryVisualization" : "NONE",
+      "sortPreference" : "",
+      "useKMG2" : false,
+      "yAxisConfigurations" : [ {
+        "id" : "yAxis0",
+        "max" : null,
+        "min" : null,
+        "name" : "yAxis0",
+        "plotlines" : {
+          "high" : null,
+          "low" : null
+        }
+      } ]
+    },
+    "currentUniqueKey" : 3,
+    "relatedDetectors" : [ ],
+    "revisionNumber" : 7
+  }
+}, {
+  "marshallId" : 55,
+  "marshallMemberOf" : [ 43 ],
+  "sf_chart" : "Bytes In / Second",
+  "sf_chartIndex" : 1528311465641,
+  "sf_description" : "Service/API-fielded request transfer rate compared with -24h",
+  "sf_type" : "Chart",
+  "sf_uiModel" : {
+    "allPlots" : [ {
+      "_originalLabel" : "A",
+      "configuration" : {
+        "aliases" : { },
+        "colorOverride" : "#007c1d",
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
+        "maxExtrapolations" : -1,
+        "prefix" : "",
+        "rollupPolicy" : null,
+        "suffix" : "",
+        "unitType" : "Byte"
+      },
+      "dataManipulations" : [ {
+        "direction" : {
+          "options" : {
+            "aggregateGroupBy" : [ ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          },
+          "type" : "aggregation"
+        },
+        "fn" : {
+          "options" : { },
+          "type" : "SUM"
+        },
+        "showMe" : false
+      } ],
+      "invisible" : false,
+      "name" : "requests",
+      "queryItems" : [ {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "plugin",
+        "propertyValue" : "kong",
+        "type" : "property",
+        "value" : "kong"
+      } ],
+      "seriesData" : {
+        "metric" : "counter.kong.requests.size",
+        "regExStyle" : null
       },
       "transient" : false,
       "type" : "plot",
@@ -10994,7 +11450,7 @@
       "expressionText" : "A",
       "invisible" : false,
       "metricDefinition" : { },
-      "name" : "responses (historic)",
+      "name" : "requests (historic)",
       "queryItems" : [ ],
       "seriesData" : {
         "metric" : null
@@ -11026,15 +11482,16 @@
     "chartconfig" : {
       "absoluteEnd" : null,
       "absoluteStart" : null,
+      "colorByMetric" : false,
       "histogramColor" : "#ea1849",
       "range" : -900000,
-      "rangeEnd" : null,
+      "rangeEnd" : 0,
       "secondaryVisualization" : "NONE",
       "sortPreference" : "",
       "useKMG2" : false,
       "yAxisConfigurations" : [ {
         "id" : "yAxis0",
-        "label" : "resp bytes/s",
+        "label" : "req bytes/s",
         "max" : null,
         "min" : null,
         "name" : "yAxis0",
@@ -11043,7 +11500,7 @@
           "low" : null
         }
       }, {
-        "label" : "resp bytes/s",
+        "label" : "req bytes/s",
         "max" : null,
         "min" : null,
         "plotlines" : {
@@ -11056,12 +11513,13 @@
       } ]
     },
     "currentUniqueKey" : 4,
+    "relatedDetectors" : [ ],
     "revisionNumber" : 9,
     "uiHelperValue" : "##CHARTID##_9"
   }
 }, {
-  "marshallId" : 53,
-  "marshallMemberOf" : [ 42 ],
+  "marshallId" : 56,
+  "marshallMemberOf" : [ 43 ],
   "sf_chart" : "Responses by Status Code",
   "sf_chartIndex" : 1528136271804,
   "sf_description" : "Number of responses per interval by status code group",
@@ -11348,6 +11806,7 @@
     "chartconfig" : {
       "absoluteEnd" : null,
       "absoluteStart" : null,
+      "colorByMetric" : false,
       "dimensionInLegend" : "sf_metric",
       "groupBy" : [ ],
       "heatmapAutoGradients" : 5,
@@ -11381,108 +11840,15 @@
       } ]
     },
     "currentUniqueKey" : 12,
-    "revisionNumber" : 22,
-    "uiHelperValue" : "##CHARTID##_22"
+    "relatedDetectors" : [ ],
+    "revisionNumber" : 23,
+    "uiHelperValue" : "##CHARTID##_23"
   }
 }, {
-  "marshallId" : 54,
-  "marshallMemberOf" : [ 42 ],
-  "sf_chart" : "# Kong Servers",
-  "sf_chartIndex" : 1528220571437,
-  "sf_description" : "Number of Kong servers actively reporting",
-  "sf_type" : "Chart",
-  "sf_uiModel" : {
-    "allPlots" : [ {
-      "_originalLabel" : "A",
-      "configuration" : {
-        "aliases" : { },
-        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
-        "maxExtrapolations" : -1,
-        "rollupPolicy" : null
-      },
-      "dataManipulations" : [ {
-        "direction" : {
-          "options" : {
-            "aggregateGroupBy" : [ ],
-            "collapseGroups" : false,
-            "transformTimeRange" : null
-          },
-          "type" : "aggregation"
-        },
-        "fn" : {
-          "options" : { },
-          "type" : "COUNT"
-        },
-        "showMe" : false
-      } ],
-      "invisible" : false,
-      "name" : "servers",
-      "queryItems" : [ {
-        "NOT" : false,
-        "iconClass" : "icon-properties",
-        "property" : "plugin",
-        "propertyValue" : "kong",
-        "type" : "property",
-        "value" : "kong"
-      } ],
-      "seriesData" : {
-        "metric" : "counter.kong.requests.count",
-        "regExStyle" : null
-      },
-      "transient" : false,
-      "type" : "plot",
-      "uniqueKey" : 1,
-      "yAxisIndex" : 0
-    }, {
-      "configuration" : {
-        "aliases" : { },
-        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
-        "maxExtrapolations" : -1
-      },
-      "dataManipulations" : [ ],
-      "invisible" : false,
-      "metricDefinition" : { },
-      "name" : "New Plot",
-      "queryItems" : [ ],
-      "seriesData" : { },
-      "transient" : true,
-      "type" : "plot",
-      "uniqueKey" : 2,
-      "yAxisIndex" : 0
-    } ],
-    "chartMode" : "single",
-    "chartType" : "line",
-    "chartconfig" : {
-      "absoluteEnd" : null,
-      "absoluteStart" : null,
-      "colorByValueScale" : [ ],
-      "hideTimestamp" : false,
-      "histogramColor" : "#ea1849",
-      "range" : -900000,
-      "rangeEnd" : null,
-      "secondaryVisualization" : "NONE",
-      "sortPreference" : "",
-      "useKMG2" : false,
-      "yAxisConfigurations" : [ {
-        "id" : "yAxis0",
-        "max" : null,
-        "min" : null,
-        "name" : "yAxis0",
-        "plotlines" : {
-          "high" : null,
-          "low" : null
-        }
-      } ]
-    },
-    "currentUniqueKey" : 3,
-    "revisionNumber" : 2,
-    "uiHelperValue" : "##CHARTID##_2"
-  }
-}, {
-  "marshallId" : 55,
-  "marshallMemberOf" : [ 42 ],
+  "marshallId" : 57,
+  "marshallMemberOf" : [ 43 ],
   "sf_chart" : "Request Latency",
-  "sf_chartIndex" : 1528729536811,
+  "sf_chartIndex" : 1528729931437,
   "sf_description" : "Average request processing time compared with -24h",
   "sf_type" : "Chart",
   "sf_uiModel" : {
@@ -11665,7 +12031,6 @@
     "chartconfig" : {
       "absoluteEnd" : null,
       "absoluteStart" : null,
-      "axisPrecision" : null,
       "colorByMetric" : false,
       "groupBy" : [ ],
       "heatmapAutoGradients" : 5,
@@ -11708,250 +12073,33 @@
     },
     "currentUniqueKey" : 11,
     "relatedDetectors" : [ ],
-    "revisionNumber" : 27,
-    "uiHelperValue" : "##CHARTID##_27"
+    "revisionNumber" : 24,
+    "uiHelperValue" : "##CHARTID##_24"
   }
 }, {
-  "marshallId" : 56,
-  "marshallMemberOf" : [ 42 ],
-  "sf_chart" : "Connections by State",
-  "sf_chartIndex" : 1528135823509,
-  "sf_description" : "Number of connections in each state",
+  "marshallId" : 58,
+  "marshallMemberOf" : [ 43 ],
+  "sf_chart" : "Responses / Second",
+  "sf_chartIndex" : 1528219376990,
+  "sf_description" : "Rate of responses by Service/API",
   "sf_type" : "Chart",
   "sf_uiModel" : {
     "allPlots" : [ {
       "_originalLabel" : "A",
       "configuration" : {
         "aliases" : { },
-        "colorOverride" : "#007c1d",
+        "colorOverride" : null,
         "extrapolationPolicy" : "NULL_EXTRAPOLATION",
-        "maxExtrapolations" : -1,
-        "rollupPolicy" : "SUM_ROLLUP"
-      },
-      "dataManipulations" : [ {
-        "direction" : {
-          "options" : {
-            "aggregateGroupBy" : [ ],
-            "collapseGroups" : false,
-            "transformTimeRange" : null
-          },
-          "type" : "aggregation"
-        },
-        "fn" : {
-          "options" : { },
-          "type" : "SUM"
-        },
-        "showMe" : false
-      } ],
-      "invisible" : false,
-      "name" : "active",
-      "queryItems" : [ {
-        "NOT" : false,
-        "iconClass" : "icon-properties",
-        "property" : "plugin",
-        "propertyValue" : "kong",
-        "type" : "property",
-        "value" : "kong"
-      } ],
-      "seriesData" : {
-        "metric" : "gauge.kong.connections.active"
-      },
-      "transient" : false,
-      "type" : "plot",
-      "uniqueKey" : 1,
-      "yAxisIndex" : 0
-    }, {
-      "_originalLabel" : "B",
-      "configuration" : {
-        "aliases" : { },
-        "colorOverride" : "#ff8dd1",
-        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
-        "maxExtrapolations" : -1,
-        "rollupPolicy" : "SUM_ROLLUP"
-      },
-      "dataManipulations" : [ {
-        "direction" : {
-          "options" : {
-            "aggregateGroupBy" : [ ],
-            "collapseGroups" : false,
-            "transformTimeRange" : null
-          },
-          "type" : "aggregation"
-        },
-        "fn" : {
-          "options" : { },
-          "type" : "SUM"
-        },
-        "showMe" : false
-      } ],
-      "invisible" : false,
-      "name" : "reading",
-      "queryItems" : [ {
-        "NOT" : false,
-        "iconClass" : "icon-properties",
-        "property" : "plugin",
-        "propertyValue" : "kong",
-        "type" : "property",
-        "value" : "kong"
-      } ],
-      "seriesData" : {
-        "metric" : "gauge.kong.connections.reading"
-      },
-      "transient" : false,
-      "type" : "plot",
-      "uniqueKey" : 2,
-      "yAxisIndex" : 0
-    }, {
-      "_originalLabel" : "C",
-      "configuration" : {
-        "aliases" : { },
-        "colorOverride" : "#e9008a",
-        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
-        "maxExtrapolations" : -1,
-        "rollupPolicy" : "SUM_ROLLUP"
-      },
-      "dataManipulations" : [ {
-        "direction" : {
-          "options" : {
-            "aggregateGroupBy" : [ ],
-            "collapseGroups" : false,
-            "transformTimeRange" : null
-          },
-          "type" : "aggregation"
-        },
-        "fn" : {
-          "options" : { },
-          "type" : "SUM"
-        },
-        "showMe" : false
-      } ],
-      "invisible" : false,
-      "name" : "waiting",
-      "queryItems" : [ {
-        "NOT" : false,
-        "iconClass" : "icon-properties",
-        "property" : "plugin",
-        "propertyValue" : "kong",
-        "type" : "property",
-        "value" : "kong"
-      } ],
-      "seriesData" : {
-        "metric" : "gauge.kong.connections.waiting"
-      },
-      "transient" : false,
-      "type" : "plot",
-      "uniqueKey" : 3,
-      "yAxisIndex" : 0
-    }, {
-      "_originalLabel" : "D",
-      "configuration" : {
-        "aliases" : { },
-        "colorOverride" : "#00b9ff",
-        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
-        "maxExtrapolations" : -1,
-        "rollupPolicy" : "SUM_ROLLUP"
-      },
-      "dataManipulations" : [ {
-        "direction" : {
-          "options" : {
-            "aggregateGroupBy" : [ ],
-            "collapseGroups" : false,
-            "transformTimeRange" : null
-          },
-          "type" : "aggregation"
-        },
-        "fn" : {
-          "options" : { },
-          "type" : "SUM"
-        },
-        "showMe" : false
-      } ],
-      "invisible" : false,
-      "name" : "writing",
-      "queryItems" : [ {
-        "NOT" : false,
-        "iconClass" : "icon-properties",
-        "property" : "plugin",
-        "propertyValue" : "kong",
-        "type" : "property",
-        "value" : "kong"
-      } ],
-      "seriesData" : {
-        "metric" : "gauge.kong.connections.writing"
-      },
-      "transient" : false,
-      "type" : "plot",
-      "uniqueKey" : 4,
-      "yAxisIndex" : 0
-    }, {
-      "configuration" : {
-        "aliases" : { },
-        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
-        "maxExtrapolations" : -1
-      },
-      "dataManipulations" : [ ],
-      "invisible" : false,
-      "metricDefinition" : { },
-      "name" : "New Plot",
-      "queryItems" : [ ],
-      "seriesData" : { },
-      "transient" : true,
-      "type" : "plot",
-      "uniqueKey" : 10,
-      "yAxisIndex" : 0
-    } ],
-    "chartMode" : "list",
-    "chartType" : "line",
-    "chartconfig" : {
-      "absoluteEnd" : null,
-      "absoluteStart" : null,
-      "colorByMetric" : false,
-      "colorByValue" : false,
-      "colorByValueScale" : [ ],
-      "histogramColor" : "#ea1849",
-      "range" : -900000,
-      "rangeEnd" : null,
-      "secondaryVisualization" : "SPARKLINE",
-      "sortPreference" : "",
-      "useKMG2" : false,
-      "yAxisConfigurations" : [ {
-        "id" : "yAxis0",
-        "max" : null,
-        "min" : null,
-        "name" : "yAxis0",
-        "plotlines" : {
-          "high" : null,
-          "low" : null
-        }
-      } ]
-    },
-    "currentUniqueKey" : 11,
-    "revisionNumber" : 11,
-    "uiHelperValue" : "##CHARTID##_11"
-  }
-}, {
-  "marshallId" : 57,
-  "marshallMemberOf" : [ 42 ],
-  "sf_chart" : "Database Reachable",
-  "sf_chartIndex" : 1528137157576,
-  "sf_description" : "Connection status as reported by kong.dao",
-  "sf_type" : "Chart",
-  "sf_uiModel" : {
-    "allPlots" : [ {
-      "_originalLabel" : "A",
-      "configuration" : {
-        "aliases" : { },
-        "extrapolationPolicy" : "LAST_VALUE_EXTRAPOLATION",
         "maxExtrapolations" : -1,
         "prefix" : "",
-        "suffix" : "",
+        "suffix" : "responses",
         "unitType" : null
       },
       "dataManipulations" : [ {
         "direction" : {
           "options" : {
             "aggregateGroupBy" : [ {
-              "value" : "host"
+              "value" : "service_name"
             } ],
             "collapseGroups" : false,
             "transformTimeRange" : null
@@ -11960,117 +12108,45 @@
         },
         "fn" : {
           "options" : { },
-          "type" : "COUNT"
+          "type" : "SUM"
         },
         "showMe" : false
       } ],
       "invisible" : false,
-      "name" : "is reachable",
+      "name" : "upstream responses (service)",
       "queryItems" : [ {
         "NOT" : false,
-        "iconClass" : "icon-properties",
+        "iconClass" : "sf-icon-property",
         "property" : "plugin",
         "propertyValue" : "kong",
+        "query" : "plugin:\"kong\"",
         "type" : "property",
         "value" : "kong"
       } ],
       "seriesData" : {
-        "metric" : "gauge.kong.database.reachable"
+        "metric" : "counter.kong.responses.count"
       },
       "transient" : false,
       "type" : "plot",
       "uniqueKey" : 1,
       "yAxisIndex" : 0
     }, {
+      "_originalLabel" : "B",
       "configuration" : {
         "aliases" : { },
-        "extrapolationPolicy" : "LAST_VALUE_EXTRAPOLATION",
-        "maxExtrapolations" : -1
-      },
-      "dataManipulations" : [ ],
-      "invisible" : false,
-      "metricDefinition" : { },
-      "name" : "New Plot",
-      "queryItems" : [ ],
-      "seriesData" : { },
-      "transient" : true,
-      "type" : "plot",
-      "uniqueKey" : 2,
-      "yAxisIndex" : 0
-    } ],
-    "chartMode" : "heatmap",
-    "chartType" : null,
-    "chartconfig" : {
-      "absoluteEnd" : null,
-      "absoluteStart" : null,
-      "colorByMetric" : false,
-      "colorByValue" : true,
-      "colorByValueScale" : [ {
-        "color" : "#6bd37e",
-        "gte" : 1
-      }, {
-        "color" : "#ea1849",
-        "lt" : 1
-      } ],
-      "groupBy" : [ ],
-      "heatmapAutoGradients" : 5,
-      "heatmapColorOverride" : "#05ce00",
-      "heatmapColorRange" : {
-        "max" : 1,
-        "min" : 0
-      },
-      "heatmapSortBy" : {
-        "asc" : true,
-        "value" : { }
-      },
-      "heatmapUnitsPerRow" : 0,
-      "heatmapUseValueAsColor" : false,
-      "hideTimestamp" : false,
-      "histogramColor" : "#ea1849",
-      "range" : -900000,
-      "rangeEnd" : null,
-      "secondaryVisualization" : "NONE",
-      "sortPreference" : "",
-      "useKMG2" : false,
-      "yAxisConfigurations" : [ {
-        "id" : "yAxis0",
-        "max" : null,
-        "min" : null,
-        "name" : "yAxis0",
-        "plotlines" : {
-          "high" : null,
-          "low" : null
-        }
-      } ]
-    },
-    "currentUniqueKey" : 3,
-    "revisionNumber" : 7,
-    "uiHelperValue" : "##CHARTID##_7"
-  }
-}, {
-  "marshallId" : 58,
-  "marshallMemberOf" : [ 42 ],
-  "sf_chart" : "Bytes In / Second",
-  "sf_chartIndex" : 1528311013969,
-  "sf_description" : "Service/API-fielded request transfer rate compared with -24h",
-  "sf_type" : "Chart",
-  "sf_uiModel" : {
-    "allPlots" : [ {
-      "_originalLabel" : "A",
-      "configuration" : {
-        "aliases" : { },
-        "colorOverride" : "#007c1d",
+        "colorOverride" : null,
         "extrapolationPolicy" : "NULL_EXTRAPOLATION",
         "maxExtrapolations" : -1,
         "prefix" : "",
-        "rollupPolicy" : null,
-        "suffix" : "",
-        "unitType" : "Byte"
+        "suffix" : "responses",
+        "unitType" : null
       },
       "dataManipulations" : [ {
         "direction" : {
           "options" : {
-            "aggregateGroupBy" : [ ],
+            "aggregateGroupBy" : [ {
+              "value" : "api_name"
+            } ],
             "collapseGroups" : false,
             "transformTimeRange" : null
           },
@@ -12083,65 +12159,23 @@
         "showMe" : false
       } ],
       "invisible" : false,
-      "name" : "requests",
+      "name" : "upstream responses (api)",
       "queryItems" : [ {
         "NOT" : false,
-        "iconClass" : "icon-properties",
+        "iconClass" : "sf-icon-property",
         "property" : "plugin",
         "propertyValue" : "kong",
+        "query" : "plugin:\"kong\"",
         "type" : "property",
         "value" : "kong"
       } ],
       "seriesData" : {
-        "metric" : "counter.kong.requests.size",
-        "regExStyle" : null
+        "metric" : "counter.kong.responses.count"
       },
       "transient" : false,
       "type" : "plot",
-      "uniqueKey" : 1,
-      "yAxisIndex" : 0
-    }, {
-      "_originalLabel" : "B",
-      "configuration" : {
-        "aliases" : { },
-        "colorOverride" : "#b04600",
-        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
-        "maxExtrapolations" : -1,
-        "prefix" : "",
-        "suffix" : "",
-        "unitType" : "Byte",
-        "visualization" : "line"
-      },
-      "dataManipulations" : [ {
-        "direction" : {
-          "options" : {
-            "aggregateGroupBy" : [ ],
-            "collapseGroups" : false,
-            "transformTimeRange" : null
-          },
-          "type" : "aggregation"
-        },
-        "fn" : {
-          "options" : {
-            "milliseconds" : 86400000
-          },
-          "type" : "TIMESHIFT"
-        },
-        "showMe" : false
-      } ],
-      "expressionText" : "A",
-      "invisible" : false,
-      "metricDefinition" : { },
-      "name" : "requests (historic)",
-      "queryItems" : [ ],
-      "seriesData" : {
-        "metric" : null
-      },
-      "transient" : false,
-      "type" : "ratio",
       "uniqueKey" : 2,
-      "valid" : true,
-      "yAxisIndex" : 1
+      "yAxisIndex" : 0
     }, {
       "configuration" : {
         "aliases" : { },
@@ -12165,15 +12199,22 @@
       "absoluteEnd" : null,
       "absoluteStart" : null,
       "colorByMetric" : false,
+      "colorByValue" : false,
+      "colorByValueScale" : [ ],
+      "dimensionInLegend" : "api_name",
+      "hideTimestamp" : false,
       "histogramColor" : "#ea1849",
-      "range" : -900000,
+      "maxDecimalPlaces" : 2,
+      "range" : -3600000,
       "rangeEnd" : 0,
       "secondaryVisualization" : "NONE",
+      "showLegend" : false,
       "sortPreference" : "",
+      "stackedChart" : true,
       "useKMG2" : false,
       "yAxisConfigurations" : [ {
         "id" : "yAxis0",
-        "label" : "req bytes/s",
+        "label" : "resp/s",
         "max" : null,
         "min" : null,
         "name" : "yAxis0",
@@ -12181,37 +12222,37 @@
           "high" : null,
           "low" : null
         }
-      }, {
-        "label" : "req bytes/s",
-        "max" : null,
-        "min" : null,
-        "plotlines" : {
-          "high" : null,
-          "low" : null
-        },
-        "title" : {
-          "text" : ""
-        }
       } ]
     },
     "currentUniqueKey" : 4,
     "relatedDetectors" : [ ],
-    "revisionNumber" : 7,
-    "uiHelperValue" : "##CHARTID##_7"
+    "revisionNumber" : 26,
+    "uiHelperValue" : "##CHARTID##_26"
   }
 }, {
   "marshallId" : 59,
   "marshallMemberOf" : [ 1 ],
-  "sf_dashboard" : "Route Objects",
-  "sf_description" : "Route object activity metrics",
-  "sf_discoveryQuery" : "plugin:kong AND __exists__:route_id",
-  "sf_discoverySelectors" : [ "plugin:kong", "__exists__:route_id" ],
+  "sf_dashboard" : "API Objects",
+  "sf_description" : "API object activity metrics",
+  "sf_discoveryQuery" : "plugin:kong AND (__exists__:api_id OR __exists__:api_name)",
+  "sf_discoverySelectors" : [ "plugin:kong", "__exists__:api_name" ],
   "sf_filterAlias" : {
     "variables" : [ {
-      "alias" : "Route ID",
+      "alias" : "API Name",
       "applyIfExists" : false,
       "description" : "",
-      "dimension" : "route_id",
+      "dimension" : "api_name",
+      "globalScope" : false,
+      "preferredSuggestions" : [ ],
+      "replaceOnly" : false,
+      "required" : false,
+      "restricted" : false,
+      "value" : ""
+    }, {
+      "alias" : "API ID",
+      "applyIfExists" : false,
+      "description" : "",
+      "dimension" : "api_id",
       "globalScope" : false,
       "preferredSuggestions" : [ ],
       "replaceOnly" : false,
@@ -12230,20 +12271,20 @@
       "relative" : true,
       "start" : "-1h"
     },
-    "variables" : [ "Route ID=route_id:" ]
+    "variables" : [ "API Name=api_name:", "API ID=api_id:" ]
   },
   "sf_selectedEventOverlays" : [ ],
   "sf_type" : "Dashboard",
   "sf_uiModel" : {
     "version" : 1,
     "widgets" : [ {
-      "col" : 0,
+      "col" : 6,
       "options" : {
-        "chartIndex" : 1528304230699,
+        "chartIndex" : 1528219376990,
         "id" : 0
       },
       "row" : 0,
-      "sizeX" : 3,
+      "sizeX" : 6,
       "sizeY" : 1
     }, {
       "col" : 3,
@@ -12255,13 +12296,13 @@
       "sizeX" : 3,
       "sizeY" : 1
     }, {
-      "col" : 6,
+      "col" : 0,
       "options" : {
-        "chartIndex" : 1528219376990,
+        "chartIndex" : 1528304230699,
         "id" : 0
       },
       "row" : 0,
-      "sizeX" : 6,
+      "sizeX" : 3,
       "sizeY" : 1
     }, {
       "col" : 6,
@@ -12340,1244 +12381,6 @@
 }, {
   "marshallId" : 60,
   "marshallMemberOf" : [ 59 ],
-  "sf_chart" : "Upstream Latency",
-  "sf_chartIndex" : 1528135368079,
-  "sf_description" : "Average latency for upstream responses compared with -24h average",
-  "sf_type" : "Chart",
-  "sf_uiModel" : {
-    "allPlots" : [ {
-      "_originalLabel" : "J",
-      "configuration" : {
-        "aliases" : { },
-        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
-        "maxExtrapolations" : -1,
-        "prefix" : "",
-        "rollupPolicy" : "LATEST_ROLLUP",
-        "suffix" : "",
-        "unitType" : "Millisecond"
-      },
-      "dataManipulations" : [ {
-        "direction" : {
-          "options" : {
-            "aggregateGroupBy" : [ {
-              "value" : "route_id"
-            } ],
-            "collapseGroups" : false,
-            "transformTimeRange" : null
-          },
-          "type" : "aggregation"
-        },
-        "fn" : {
-          "options" : { },
-          "type" : "SUM"
-        },
-        "showMe" : false
-      } ],
-      "invisible" : true,
-      "name" : "counter.kong.upstream.latency - Sum by route_id",
-      "queryItems" : [ {
-        "NOT" : false,
-        "iconClass" : "icon-properties",
-        "property" : "plugin",
-        "propertyValue" : "kong",
-        "type" : "property",
-        "value" : "kong"
-      }, {
-        "NOT" : false,
-        "iconClass" : "icon-properties",
-        "property" : "route_id",
-        "propertyValue" : "*",
-        "type" : "property",
-        "value" : "*"
-      } ],
-      "seriesData" : {
-        "metric" : "counter.kong.upstream.latency",
-        "regExStyle" : null
-      },
-      "transient" : false,
-      "type" : "plot",
-      "uniqueKey" : 10,
-      "yAxisIndex" : 0
-    }, {
-      "_originalLabel" : "K",
-      "configuration" : {
-        "aliases" : { },
-        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
-        "maxExtrapolations" : -1,
-        "rollupPolicy" : "LATEST_ROLLUP"
-      },
-      "dataManipulations" : [ {
-        "direction" : {
-          "options" : {
-            "aggregateGroupBy" : [ {
-              "value" : "route_id"
-            } ],
-            "collapseGroups" : false,
-            "transformTimeRange" : null
-          },
-          "type" : "aggregation"
-        },
-        "fn" : {
-          "options" : { },
-          "type" : "SUM"
-        },
-        "showMe" : false
-      } ],
-      "invisible" : true,
-      "metricDefinition" : { },
-      "name" : "counter.kong.responses.count - Sum by route_id",
-      "queryItems" : [ {
-        "NOT" : false,
-        "iconClass" : "icon-properties",
-        "property" : "plugin",
-        "propertyValue" : "kong",
-        "type" : "property",
-        "value" : "kong"
-      }, {
-        "NOT" : false,
-        "iconClass" : "icon-properties",
-        "property" : "route_id",
-        "propertyValue" : "*",
-        "type" : "property",
-        "value" : "*"
-      } ],
-      "seriesData" : {
-        "metric" : "counter.kong.responses.count",
-        "regExStyle" : null
-      },
-      "transient" : false,
-      "type" : "plot",
-      "uniqueKey" : 11,
-      "yAxisIndex" : 0
-    }, {
-      "_originalLabel" : "L",
-      "configuration" : {
-        "aliases" : { },
-        "colorOverride" : null,
-        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
-        "maxExtrapolations" : -1,
-        "prefix" : "",
-        "suffix" : "",
-        "unitType" : "Millisecond"
-      },
-      "dataManipulations" : [ ],
-      "expressionText" : "J / K",
-      "invisible" : false,
-      "metricDefinition" : { },
-      "name" : "latency",
-      "queryItems" : [ ],
-      "seriesData" : {
-        "metric" : null
-      },
-      "transient" : false,
-      "type" : "ratio",
-      "uniqueKey" : 12,
-      "valid" : true,
-      "yAxisIndex" : 0
-    }, {
-      "_originalLabel" : "O",
-      "configuration" : {
-        "aliases" : { },
-        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
-        "maxExtrapolations" : -1
-      },
-      "dataManipulations" : [ {
-        "direction" : {
-          "options" : {
-            "aggregateGroupBy" : [ ],
-            "collapseGroups" : false,
-            "transformTimeRange" : null
-          },
-          "type" : "aggregation"
-        },
-        "fn" : {
-          "options" : { },
-          "type" : "SUM"
-        },
-        "showMe" : false
-      } ],
-      "expressionText" : "J",
-      "invisible" : true,
-      "metricDefinition" : { },
-      "name" : "J - Sum",
-      "queryItems" : [ ],
-      "seriesData" : {
-        "metric" : null
-      },
-      "transient" : false,
-      "type" : "ratio",
-      "uniqueKey" : 15,
-      "valid" : true,
-      "yAxisIndex" : 0
-    }, {
-      "_originalLabel" : "P",
-      "configuration" : {
-        "aliases" : { },
-        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
-        "maxExtrapolations" : -1
-      },
-      "dataManipulations" : [ {
-        "direction" : {
-          "options" : {
-            "aggregateGroupBy" : [ ],
-            "collapseGroups" : false,
-            "transformTimeRange" : null
-          },
-          "type" : "aggregation"
-        },
-        "fn" : {
-          "options" : { },
-          "type" : "SUM"
-        },
-        "showMe" : false
-      } ],
-      "expressionText" : "K",
-      "invisible" : true,
-      "metricDefinition" : { },
-      "name" : "K - Sum",
-      "queryItems" : [ ],
-      "seriesData" : {
-        "metric" : null
-      },
-      "transient" : false,
-      "type" : "ratio",
-      "uniqueKey" : 16,
-      "valid" : true,
-      "yAxisIndex" : 0
-    }, {
-      "_originalLabel" : "Q",
-      "configuration" : {
-        "aliases" : { },
-        "colorOverride" : null,
-        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
-        "maxExtrapolations" : -1,
-        "prefix" : "",
-        "suffix" : "",
-        "unitType" : "Millisecond",
-        "visualization" : "line"
-      },
-      "dataManipulations" : [ {
-        "direction" : {
-          "options" : {
-            "aggregateGroupBy" : [ ],
-            "collapseGroups" : false,
-            "transformTimeRange" : null
-          },
-          "type" : "aggregation"
-        },
-        "fn" : {
-          "options" : {
-            "milliseconds" : 86400000
-          },
-          "type" : "TIMESHIFT"
-        },
-        "showMe" : false
-      } ],
-      "expressionText" : "O/P",
-      "invisible" : false,
-      "metricDefinition" : { },
-      "name" : "latency (historic)",
-      "queryItems" : [ ],
-      "seriesData" : {
-        "metric" : null
-      },
-      "transient" : false,
-      "type" : "ratio",
-      "uniqueKey" : 17,
-      "valid" : true,
-      "yAxisIndex" : 1
-    }, {
-      "configuration" : {
-        "aliases" : { },
-        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
-        "maxExtrapolations" : -1
-      },
-      "dataManipulations" : [ ],
-      "invisible" : false,
-      "metricDefinition" : { },
-      "name" : "New Plot",
-      "queryItems" : [ ],
-      "seriesData" : { },
-      "transient" : true,
-      "type" : "plot",
-      "uniqueKey" : 18,
-      "yAxisIndex" : 0
-    } ],
-    "chartMode" : "graph",
-    "chartType" : "heatmap",
-    "chartconfig" : {
-      "absoluteEnd" : null,
-      "absoluteStart" : null,
-      "colorByMetric" : false,
-      "colorByValue" : false,
-      "colorByValueScale" : [ ],
-      "histogramColor" : "#a747ff",
-      "range" : -1800000,
-      "rangeEnd" : 0,
-      "secondaryVisualization" : "SPARKLINE",
-      "sortPreference" : "-value",
-      "stackedChart" : false,
-      "useKMG2" : false,
-      "yAxisConfigurations" : [ {
-        "id" : "yAxis0",
-        "label" : "latency/resp",
-        "max" : null,
-        "min" : null,
-        "name" : "yAxis0",
-        "plotlines" : {
-          "high" : null,
-          "low" : null
-        }
-      }, {
-        "label" : "latency/resp",
-        "max" : null,
-        "min" : null,
-        "plotlines" : {
-          "high" : null,
-          "low" : null
-        },
-        "title" : {
-          "text" : ""
-        }
-      } ]
-    },
-    "currentUniqueKey" : 19,
-    "relatedDetectors" : [ ],
-    "revisionNumber" : 35,
-    "uiHelperValue" : "##CHARTID##_35"
-  }
-}, {
-  "marshallId" : 61,
-  "marshallMemberOf" : [ 59 ],
-  "sf_chart" : "Responses by Status Code",
-  "sf_chartIndex" : 1528136271804,
-  "sf_description" : "Number of responses per interval by status code group",
-  "sf_type" : "Chart",
-  "sf_uiModel" : {
-    "allPlots" : [ {
-      "_originalLabel" : "E",
-      "configuration" : {
-        "aliases" : { },
-        "colorOverride" : "#999999",
-        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
-        "maxExtrapolations" : -1,
-        "rollupPolicy" : "SUM_ROLLUP",
-        "suffix" : "responses",
-        "unitType" : null
-      },
-      "dataManipulations" : [ {
-        "direction" : {
-          "options" : {
-            "aggregateGroupBy" : [ ],
-            "collapseGroups" : false,
-            "transformTimeRange" : null
-          },
-          "type" : "aggregation"
-        },
-        "fn" : {
-          "options" : { },
-          "type" : "SUM"
-        },
-        "showMe" : false
-      } ],
-      "invisible" : false,
-      "metricDefinition" : { },
-      "name" : "1xx",
-      "queryItems" : [ {
-        "NOT" : false,
-        "iconClass" : "icon-properties",
-        "isSynthetic" : true,
-        "property" : "plugin",
-        "propertyValue" : "kong",
-        "type" : "property",
-        "value" : "kong"
-      }, {
-        "NOT" : false,
-        "iconClass" : "icon-properties",
-        "property" : "status_code",
-        "propertyValue" : "1*",
-        "type" : "property",
-        "value" : "1*"
-      }, {
-        "NOT" : false,
-        "iconClass" : "icon-properties",
-        "property" : "route_id",
-        "propertyValue" : "*",
-        "type" : "property",
-        "value" : "*"
-      } ],
-      "seriesData" : {
-        "metric" : "counter.kong.responses.count",
-        "regExStyle" : null
-      },
-      "transient" : false,
-      "type" : "plot",
-      "uniqueKey" : 5,
-      "yAxisIndex" : 0
-    }, {
-      "_originalLabel" : "A",
-      "configuration" : {
-        "aliases" : { },
-        "colorOverride" : "#00b9ff",
-        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
-        "maxExtrapolations" : -1,
-        "rollupPolicy" : "DELTA_ROLLUP",
-        "suffix" : "responses",
-        "unitType" : null
-      },
-      "dataManipulations" : [ {
-        "direction" : {
-          "options" : {
-            "aggregateGroupBy" : [ ],
-            "collapseGroups" : false,
-            "transformTimeRange" : null
-          },
-          "type" : "aggregation"
-        },
-        "fn" : {
-          "options" : { },
-          "type" : "SUM"
-        },
-        "showMe" : false
-      } ],
-      "invisible" : false,
-      "name" : "2xx",
-      "queryItems" : [ {
-        "NOT" : false,
-        "iconClass" : "icon-properties",
-        "property" : "plugin",
-        "propertyValue" : "kong",
-        "type" : "property",
-        "value" : "kong"
-      }, {
-        "NOT" : false,
-        "iconClass" : "icon-properties",
-        "property" : "status_code",
-        "propertyValue" : "2*",
-        "type" : "property",
-        "value" : "2*"
-      }, {
-        "NOT" : false,
-        "iconClass" : "icon-properties",
-        "property" : "route_id",
-        "propertyValue" : "*",
-        "type" : "property",
-        "value" : "*"
-      } ],
-      "seriesData" : {
-        "metric" : "counter.kong.responses.count"
-      },
-      "transient" : false,
-      "type" : "plot",
-      "uniqueKey" : 1,
-      "yAxisIndex" : 0
-    }, {
-      "_originalLabel" : "C",
-      "configuration" : {
-        "aliases" : { },
-        "colorOverride" : "#e5b312",
-        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
-        "maxExtrapolations" : -1,
-        "rollupPolicy" : "DELTA_ROLLUP",
-        "suffix" : "responses",
-        "unitType" : null
-      },
-      "dataManipulations" : [ {
-        "direction" : {
-          "options" : {
-            "aggregateGroupBy" : [ ],
-            "collapseGroups" : false,
-            "transformTimeRange" : null
-          },
-          "type" : "aggregation"
-        },
-        "fn" : {
-          "options" : { },
-          "type" : "SUM"
-        },
-        "showMe" : false
-      } ],
-      "invisible" : false,
-      "metricDefinition" : { },
-      "name" : "3xx",
-      "queryItems" : [ {
-        "NOT" : false,
-        "iconClass" : "icon-properties",
-        "property" : "plugin",
-        "propertyValue" : "kong",
-        "type" : "property",
-        "value" : "kong"
-      }, {
-        "NOT" : false,
-        "iconClass" : "icon-properties",
-        "property" : "status_code",
-        "propertyValue" : "3*",
-        "type" : "property",
-        "value" : "3*"
-      }, {
-        "NOT" : false,
-        "iconClass" : "icon-properties",
-        "property" : "route_id",
-        "propertyValue" : "*",
-        "type" : "property",
-        "value" : "*"
-      } ],
-      "seriesData" : {
-        "metric" : "counter.kong.responses.count",
-        "regExStyle" : null
-      },
-      "transient" : false,
-      "type" : "plot",
-      "uniqueKey" : 3,
-      "yAxisIndex" : 0
-    }, {
-      "_originalLabel" : "B",
-      "configuration" : {
-        "aliases" : { },
-        "colorOverride" : "#b04600",
-        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
-        "maxExtrapolations" : -1,
-        "rollupPolicy" : "DELTA_ROLLUP",
-        "suffix" : "responses",
-        "unitType" : null
-      },
-      "dataManipulations" : [ {
-        "direction" : {
-          "options" : {
-            "aggregateGroupBy" : [ ],
-            "collapseGroups" : false,
-            "transformTimeRange" : null
-          },
-          "type" : "aggregation"
-        },
-        "fn" : {
-          "options" : { },
-          "type" : "SUM"
-        },
-        "showMe" : false
-      } ],
-      "invisible" : false,
-      "metricDefinition" : { },
-      "name" : "4xx",
-      "queryItems" : [ {
-        "NOT" : false,
-        "iconClass" : "icon-properties",
-        "property" : "plugin",
-        "propertyValue" : "kong",
-        "type" : "property",
-        "value" : "kong"
-      }, {
-        "NOT" : false,
-        "iconClass" : "icon-properties",
-        "property" : "status_code",
-        "propertyValue" : "4*",
-        "type" : "property",
-        "value" : "4*"
-      }, {
-        "NOT" : false,
-        "iconClass" : "icon-properties",
-        "property" : "route_id",
-        "propertyValue" : "*",
-        "type" : "property",
-        "value" : "*"
-      } ],
-      "seriesData" : {
-        "metric" : "counter.kong.responses.count",
-        "regExStyle" : null
-      },
-      "transient" : false,
-      "type" : "plot",
-      "uniqueKey" : 2,
-      "yAxisIndex" : 0
-    }, {
-      "_originalLabel" : "D",
-      "configuration" : {
-        "aliases" : { },
-        "colorOverride" : "#e9008a",
-        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
-        "maxExtrapolations" : -1,
-        "rollupPolicy" : "DELTA_ROLLUP",
-        "suffix" : "responses",
-        "unitType" : null
-      },
-      "dataManipulations" : [ {
-        "direction" : {
-          "options" : {
-            "aggregateGroupBy" : [ ],
-            "collapseGroups" : false,
-            "transformTimeRange" : null
-          },
-          "type" : "aggregation"
-        },
-        "fn" : {
-          "options" : { },
-          "type" : "SUM"
-        },
-        "showMe" : false
-      } ],
-      "invisible" : false,
-      "metricDefinition" : { },
-      "name" : "5xx",
-      "queryItems" : [ {
-        "NOT" : false,
-        "iconClass" : "icon-properties",
-        "property" : "plugin",
-        "propertyValue" : "kong",
-        "type" : "property",
-        "value" : "kong"
-      }, {
-        "NOT" : false,
-        "iconClass" : "icon-properties",
-        "property" : "status_code",
-        "propertyValue" : "5*",
-        "type" : "property",
-        "value" : "5*"
-      }, {
-        "NOT" : false,
-        "iconClass" : "icon-properties",
-        "property" : "route_id",
-        "propertyValue" : "*",
-        "type" : "property",
-        "value" : "*"
-      } ],
-      "seriesData" : {
-        "metric" : "counter.kong.responses.count",
-        "regExStyle" : null
-      },
-      "transient" : false,
-      "type" : "plot",
-      "uniqueKey" : 4,
-      "yAxisIndex" : 0
-    }, {
-      "configuration" : {
-        "aliases" : { },
-        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
-        "maxExtrapolations" : -1
-      },
-      "dataManipulations" : [ ],
-      "invisible" : false,
-      "metricDefinition" : { },
-      "name" : "New Plot",
-      "queryItems" : [ ],
-      "seriesData" : { },
-      "transient" : true,
-      "type" : "plot",
-      "uniqueKey" : 11,
-      "yAxisIndex" : 0
-    } ],
-    "chartMode" : "graph",
-    "chartType" : "area",
-    "chartconfig" : {
-      "absoluteEnd" : null,
-      "absoluteStart" : null,
-      "colorByMetric" : false,
-      "dimensionInLegend" : "sf_metric",
-      "groupBy" : [ ],
-      "heatmapAutoGradients" : 5,
-      "heatmapColorRange" : { },
-      "heatmapSortBy" : {
-        "asc" : true,
-        "value" : { }
-      },
-      "heatmapUnitsPerRow" : 0,
-      "heatmapUseValueAsColor" : false,
-      "hideTimestamp" : false,
-      "histogramColor" : "#ea1849",
-      "legendColumnConfiguration" : null,
-      "range" : -1800000,
-      "rangeEnd" : 0,
-      "secondaryVisualization" : "NONE",
-      "showLegend" : true,
-      "sortPreference" : "",
-      "stackedChart" : true,
-      "useKMG2" : false,
-      "yAxisConfigurations" : [ {
-        "id" : "yAxis0",
-        "label" : "resp/intvl",
-        "max" : null,
-        "min" : null,
-        "name" : "yAxis0",
-        "plotlines" : {
-          "high" : null,
-          "low" : null
-        }
-      } ]
-    },
-    "currentUniqueKey" : 12,
-    "relatedDetectors" : [ ],
-    "revisionNumber" : 25,
-    "uiHelperValue" : "##CHARTID##_25"
-  }
-}, {
-  "marshallId" : 62,
-  "marshallMemberOf" : [ 59 ],
-  "sf_chart" : "5xx Responses by HTTP Method",
-  "sf_chartIndex" : 1528313719962,
-  "sf_description" : "Number of 5xx errors per interval by HTTP method",
-  "sf_type" : "Chart",
-  "sf_uiModel" : {
-    "allPlots" : [ {
-      "_originalLabel" : "A",
-      "configuration" : {
-        "aliases" : { },
-        "colorOverride" : null,
-        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
-        "maxExtrapolations" : -1,
-        "rollupPolicy" : "DELTA_ROLLUP",
-        "suffix" : "errors",
-        "unitType" : null
-      },
-      "dataManipulations" : [ {
-        "direction" : {
-          "options" : {
-            "aggregateGroupBy" : [ {
-              "value" : "http_method"
-            }, {
-              "value" : "status_code"
-            } ],
-            "collapseGroups" : false,
-            "transformTimeRange" : null
-          },
-          "type" : "aggregation"
-        },
-        "fn" : {
-          "options" : { },
-          "type" : "SUM"
-        },
-        "showMe" : false
-      } ],
-      "invisible" : false,
-      "name" : "errors",
-      "queryItems" : [ {
-        "NOT" : false,
-        "iconClass" : "icon-properties",
-        "property" : "plugin",
-        "propertyValue" : "kong",
-        "type" : "property",
-        "value" : "kong"
-      }, {
-        "NOT" : false,
-        "iconClass" : "icon-properties",
-        "property" : "status_code",
-        "propertyValue" : "5*",
-        "type" : "property",
-        "value" : "201"
-      }, {
-        "NOT" : false,
-        "iconClass" : "icon-properties",
-        "property" : "route_id",
-        "propertyValue" : "*",
-        "type" : "property",
-        "value" : "*"
-      } ],
-      "seriesData" : {
-        "metric" : "counter.kong.responses.count",
-        "regExStyle" : null
-      },
-      "transient" : false,
-      "type" : "plot",
-      "uniqueKey" : 1,
-      "yAxisIndex" : 0
-    }, {
-      "configuration" : {
-        "aliases" : { },
-        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
-        "maxExtrapolations" : -1
-      },
-      "dataManipulations" : [ ],
-      "invisible" : false,
-      "metricDefinition" : { },
-      "name" : "New Plot",
-      "queryItems" : [ ],
-      "seriesData" : { },
-      "transient" : true,
-      "type" : "plot",
-      "uniqueKey" : 18,
-      "yAxisIndex" : 0
-    } ],
-    "chartMode" : "graph",
-    "chartType" : "column",
-    "chartconfig" : {
-      "absoluteEnd" : null,
-      "absoluteStart" : null,
-      "colorByMetric" : false,
-      "colorByValue" : false,
-      "colorByValueScale" : [ ],
-      "groupBy" : [ ],
-      "heatmapAutoGradients" : 5,
-      "heatmapColorRange" : { },
-      "heatmapSortBy" : {
-        "asc" : true,
-        "value" : { }
-      },
-      "heatmapUnitsPerRow" : 0,
-      "heatmapUseValueAsColor" : false,
-      "hideTimestamp" : false,
-      "histogramColor" : "#ea1849",
-      "maxDecimalPlaces" : 4,
-      "range" : -1800000,
-      "rangeEnd" : 0,
-      "secondaryVisualization" : "SPARKLINE",
-      "sortPreference" : "",
-      "stackedChart" : true,
-      "useKMG2" : false,
-      "yAxisConfigurations" : [ {
-        "id" : "yAxis0",
-        "label" : "errors/intvl",
-        "max" : null,
-        "min" : null,
-        "name" : "yAxis0",
-        "plotlines" : {
-          "high" : null,
-          "low" : null
-        }
-      } ]
-    },
-    "currentUniqueKey" : 19,
-    "relatedDetectors" : [ ],
-    "revisionNumber" : 29,
-    "uiHelperValue" : "##CHARTID##_29"
-  }
-}, {
-  "marshallId" : 63,
-  "marshallMemberOf" : [ 59 ],
-  "sf_chart" : "Responses / Second",
-  "sf_chartIndex" : 1528134810674,
-  "sf_description" : "Rate of Route responses",
-  "sf_type" : "Chart",
-  "sf_uiModel" : {
-    "allPlots" : [ {
-      "_originalLabel" : "A",
-      "configuration" : {
-        "aliases" : { },
-        "colorOverride" : "#0077c2",
-        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
-        "maxExtrapolations" : -1,
-        "prefix" : "",
-        "suffix" : "",
-        "unitType" : null
-      },
-      "dataManipulations" : [ {
-        "direction" : {
-          "options" : {
-            "aggregateGroupBy" : [ ],
-            "collapseGroups" : false,
-            "transformTimeRange" : null
-          },
-          "type" : "aggregation"
-        },
-        "fn" : {
-          "options" : { },
-          "type" : "SUM"
-        },
-        "showMe" : false
-      } ],
-      "invisible" : false,
-      "name" : "responses",
-      "queryItems" : [ {
-        "NOT" : false,
-        "iconClass" : "sf-icon-property",
-        "property" : "plugin",
-        "propertyValue" : "kong",
-        "query" : "plugin:\"kong\"",
-        "type" : "property",
-        "value" : "kong"
-      }, {
-        "NOT" : false,
-        "iconClass" : "icon-properties",
-        "property" : "route_id",
-        "propertyValue" : "*",
-        "type" : "property",
-        "value" : "*"
-      } ],
-      "seriesData" : {
-        "metric" : "counter.kong.responses.count"
-      },
-      "transient" : false,
-      "type" : "plot",
-      "uniqueKey" : 1,
-      "yAxisIndex" : 0
-    }, {
-      "configuration" : {
-        "aliases" : { },
-        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
-        "maxExtrapolations" : -1
-      },
-      "dataManipulations" : [ ],
-      "invisible" : false,
-      "metricDefinition" : { },
-      "name" : "New Plot",
-      "queryItems" : [ ],
-      "seriesData" : { },
-      "transient" : true,
-      "type" : "plot",
-      "uniqueKey" : 2,
-      "yAxisIndex" : 0
-    } ],
-    "chartMode" : "single",
-    "chartType" : "line",
-    "chartconfig" : {
-      "absoluteEnd" : null,
-      "absoluteStart" : null,
-      "colorByMetric" : false,
-      "colorByValue" : false,
-      "colorByValueScale" : [ ],
-      "hideTimestamp" : false,
-      "histogramColor" : "#ea1849",
-      "maxDecimalPlaces" : 2,
-      "range" : -1800000,
-      "rangeEnd" : 0,
-      "secondaryVisualization" : "NONE",
-      "sortPreference" : "",
-      "useKMG2" : false,
-      "yAxisConfigurations" : [ {
-        "id" : "yAxis0",
-        "max" : null,
-        "min" : null,
-        "name" : "yAxis0",
-        "plotlines" : {
-          "high" : null,
-          "low" : null
-        }
-      } ]
-    },
-    "currentUniqueKey" : 3,
-    "relatedDetectors" : [ ],
-    "revisionNumber" : 22,
-    "uiHelperValue" : "##CHARTID##_22"
-  }
-}, {
-  "marshallId" : 64,
-  "marshallMemberOf" : [ 59 ],
-  "sf_chart" : "4xx Responses by HTTP Method",
-  "sf_chartIndex" : 1528312603879,
-  "sf_description" : "Number of 4xx errors per interval by HTTP method",
-  "sf_type" : "Chart",
-  "sf_uiModel" : {
-    "allPlots" : [ {
-      "_originalLabel" : "A",
-      "configuration" : {
-        "aliases" : { },
-        "colorOverride" : null,
-        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
-        "maxExtrapolations" : -1,
-        "rollupPolicy" : "DELTA_ROLLUP",
-        "suffix" : "errors",
-        "unitType" : null
-      },
-      "dataManipulations" : [ {
-        "direction" : {
-          "options" : {
-            "aggregateGroupBy" : [ {
-              "value" : "http_method"
-            }, {
-              "value" : "status_code"
-            } ],
-            "collapseGroups" : false,
-            "transformTimeRange" : null
-          },
-          "type" : "aggregation"
-        },
-        "fn" : {
-          "options" : { },
-          "type" : "SUM"
-        },
-        "showMe" : false
-      } ],
-      "invisible" : false,
-      "name" : "errors",
-      "queryItems" : [ {
-        "NOT" : false,
-        "iconClass" : "icon-properties",
-        "property" : "plugin",
-        "propertyValue" : "kong",
-        "type" : "property",
-        "value" : "kong"
-      }, {
-        "NOT" : false,
-        "iconClass" : "icon-properties",
-        "property" : "status_code",
-        "propertyValue" : "4*",
-        "type" : "property",
-        "value" : "201"
-      }, {
-        "NOT" : false,
-        "iconClass" : "icon-properties",
-        "property" : "route_id",
-        "propertyValue" : "*",
-        "type" : "property",
-        "value" : "*"
-      } ],
-      "seriesData" : {
-        "metric" : "counter.kong.responses.count",
-        "regExStyle" : null
-      },
-      "transient" : false,
-      "type" : "plot",
-      "uniqueKey" : 1,
-      "yAxisIndex" : 0
-    }, {
-      "configuration" : {
-        "aliases" : { },
-        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
-        "maxExtrapolations" : -1
-      },
-      "dataManipulations" : [ ],
-      "invisible" : false,
-      "metricDefinition" : { },
-      "name" : "New Plot",
-      "queryItems" : [ ],
-      "seriesData" : { },
-      "transient" : true,
-      "type" : "plot",
-      "uniqueKey" : 18,
-      "yAxisIndex" : 0
-    } ],
-    "chartMode" : "graph",
-    "chartType" : "column",
-    "chartconfig" : {
-      "absoluteEnd" : null,
-      "absoluteStart" : null,
-      "colorByMetric" : false,
-      "colorByValue" : false,
-      "colorByValueScale" : [ ],
-      "groupBy" : [ ],
-      "heatmapAutoGradients" : 5,
-      "heatmapColorRange" : { },
-      "heatmapSortBy" : {
-        "asc" : true,
-        "value" : { }
-      },
-      "heatmapUnitsPerRow" : 0,
-      "heatmapUseValueAsColor" : false,
-      "hideTimestamp" : false,
-      "histogramColor" : "#ea1849",
-      "maxDecimalPlaces" : 4,
-      "range" : -1800000,
-      "rangeEnd" : 0,
-      "secondaryVisualization" : "SPARKLINE",
-      "sortPreference" : "",
-      "stackedChart" : true,
-      "useKMG2" : false,
-      "yAxisConfigurations" : [ {
-        "id" : "yAxis0",
-        "label" : "errors/intvl",
-        "max" : null,
-        "min" : null,
-        "name" : "yAxis0",
-        "plotlines" : {
-          "high" : null,
-          "low" : null
-        }
-      } ]
-    },
-    "currentUniqueKey" : 19,
-    "relatedDetectors" : [ ],
-    "revisionNumber" : 32,
-    "uiHelperValue" : "##CHARTID##_32"
-  }
-}, {
-  "marshallId" : 65,
-  "marshallMemberOf" : [ 59 ],
-  "sf_chart" : "Responses",
-  "sf_chartIndex" : 1528304230699,
-  "sf_description" : "Within past hour",
-  "sf_type" : "Chart",
-  "sf_uiModel" : {
-    "allPlots" : [ {
-      "_originalLabel" : "A",
-      "configuration" : {
-        "aliases" : { },
-        "colorOverride" : null,
-        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
-        "maxExtrapolations" : -1,
-        "prefix" : "",
-        "rollupPolicy" : "SUM_ROLLUP",
-        "suffix" : "",
-        "unitType" : null
-      },
-      "dataManipulations" : [ {
-        "direction" : {
-          "options" : {
-            "aggregateGroupBy" : [ ],
-            "collapseGroups" : false,
-            "transformTimeRange" : null
-          },
-          "type" : "aggregation"
-        },
-        "fn" : {
-          "options" : { },
-          "type" : "SUM"
-        },
-        "showMe" : false
-      } ],
-      "invisible" : true,
-      "name" : "counter.kong.responses.count - Sum",
-      "queryItems" : [ {
-        "NOT" : false,
-        "iconClass" : "sf-icon-property",
-        "property" : "plugin",
-        "propertyValue" : "kong",
-        "query" : "plugin:\"kong\"",
-        "type" : "property",
-        "value" : "kong"
-      }, {
-        "NOT" : false,
-        "iconClass" : "icon-properties",
-        "property" : "route_id",
-        "propertyValue" : "*",
-        "type" : "property",
-        "value" : "*"
-      } ],
-      "seriesData" : {
-        "metric" : "counter.kong.responses.count"
-      },
-      "transient" : false,
-      "type" : "plot",
-      "uniqueKey" : 1,
-      "yAxisIndex" : 0
-    }, {
-      "_originalLabel" : "B",
-      "configuration" : {
-        "aliases" : { },
-        "colorOverride" : null,
-        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
-        "maxExtrapolations" : -1,
-        "prefix" : "",
-        "rollupPolicy" : "SUM_ROLLUP",
-        "suffix" : "",
-        "unitType" : null
-      },
-      "dataManipulations" : [ {
-        "direction" : {
-          "options" : {
-            "aggregateGroupBy" : [ ],
-            "collapseGroups" : false,
-            "transformTimeRange" : null
-          },
-          "type" : "aggregation"
-        },
-        "fn" : {
-          "options" : {
-            "milliseconds" : 3600000
-          },
-          "type" : "TIMESHIFT"
-        },
-        "showMe" : false
-      }, {
-        "direction" : {
-          "options" : {
-            "aggregateGroupBy" : [ ],
-            "collapseGroups" : false,
-            "transformTimeRange" : null
-          },
-          "type" : "aggregation"
-        },
-        "fn" : {
-          "options" : { },
-          "type" : "SUM"
-        },
-        "showMe" : false
-      } ],
-      "invisible" : true,
-      "name" : "counter.kong.responses.count - Timeshift 1h - Sum",
-      "queryItems" : [ {
-        "NOT" : false,
-        "iconClass" : "sf-icon-property",
-        "property" : "plugin",
-        "propertyValue" : "kong",
-        "query" : "plugin:\"kong\"",
-        "type" : "property",
-        "value" : "kong"
-      }, {
-        "NOT" : false,
-        "iconClass" : "icon-properties",
-        "property" : "route_id",
-        "propertyValue" : "*",
-        "type" : "property",
-        "value" : "*"
-      } ],
-      "seriesData" : {
-        "metric" : "counter.kong.responses.count"
-      },
-      "transient" : false,
-      "type" : "plot",
-      "uniqueKey" : 2,
-      "yAxisIndex" : 0
-    }, {
-      "_originalLabel" : "C",
-      "configuration" : {
-        "aliases" : { },
-        "colorOverride" : "#00b9ff",
-        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
-        "maxExtrapolations" : -1
-      },
-      "dataManipulations" : [ ],
-      "expressionText" : "A-B",
-      "invisible" : false,
-      "metricDefinition" : { },
-      "name" : "A-B",
-      "queryItems" : [ ],
-      "seriesData" : {
-        "metric" : null
-      },
-      "transient" : false,
-      "type" : "ratio",
-      "uniqueKey" : 3,
-      "valid" : true,
-      "yAxisIndex" : 0
-    }, {
-      "configuration" : {
-        "aliases" : { },
-        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
-        "maxExtrapolations" : -1
-      },
-      "dataManipulations" : [ ],
-      "invisible" : false,
-      "metricDefinition" : { },
-      "name" : "New Plot",
-      "queryItems" : [ ],
-      "seriesData" : { },
-      "transient" : true,
-      "type" : "plot",
-      "uniqueKey" : 4,
-      "yAxisIndex" : 0
-    } ],
-    "chartMode" : "single",
-    "chartType" : "line",
-    "chartconfig" : {
-      "absoluteEnd" : null,
-      "absoluteStart" : null,
-      "colorByMetric" : false,
-      "colorByValue" : false,
-      "colorByValueScale" : [ ],
-      "hideTimestamp" : false,
-      "histogramColor" : "#ea1849",
-      "maxDecimalPlaces" : 2,
-      "range" : -1800000,
-      "rangeEnd" : 0,
-      "secondaryVisualization" : "NONE",
-      "sortPreference" : "",
-      "useKMG2" : false,
-      "yAxisConfigurations" : [ {
-        "id" : "yAxis0",
-        "max" : null,
-        "min" : null,
-        "name" : "yAxis0",
-        "plotlines" : {
-          "high" : null,
-          "low" : null
-        }
-      } ]
-    },
-    "currentUniqueKey" : 5,
-    "relatedDetectors" : [ ],
-    "revisionNumber" : 24,
-    "uiHelperValue" : "##CHARTID##_24"
-  }
-}, {
-  "marshallId" : 66,
-  "marshallMemberOf" : [ 59 ],
   "sf_chart" : "Kong Latency",
   "sf_chartIndex" : 1528147046843,
   "sf_description" : "Average Kong-induced latency for requests compared with -24h average",
@@ -13598,7 +12401,7 @@
         "direction" : {
           "options" : {
             "aggregateGroupBy" : [ {
-              "value" : "route_id"
+              "value" : "api_name"
             } ],
             "collapseGroups" : false,
             "transformTimeRange" : null
@@ -13612,7 +12415,7 @@
         "showMe" : false
       } ],
       "invisible" : true,
-      "name" : "counter.kong.kong.latency - Sum by route_id",
+      "name" : "counter.kong.kong.latency - Sum by api_name",
       "queryItems" : [ {
         "NOT" : false,
         "iconClass" : "icon-properties",
@@ -13623,7 +12426,7 @@
       }, {
         "NOT" : false,
         "iconClass" : "icon-properties",
-        "property" : "route_id",
+        "property" : "api_name",
         "propertyValue" : "*",
         "type" : "property",
         "value" : "*"
@@ -13649,7 +12452,7 @@
         "direction" : {
           "options" : {
             "aggregateGroupBy" : [ {
-              "value" : "route_id"
+              "value" : "api_name"
             } ],
             "collapseGroups" : false,
             "transformTimeRange" : null
@@ -13664,7 +12467,7 @@
       } ],
       "invisible" : true,
       "metricDefinition" : { },
-      "name" : "counter.kong.responses.count - Sum by route_id",
+      "name" : "counter.kong.responses.count - Sum by api_name",
       "queryItems" : [ {
         "NOT" : false,
         "iconClass" : "icon-properties",
@@ -13675,7 +12478,7 @@
       }, {
         "NOT" : false,
         "iconClass" : "icon-properties",
-        "property" : "route_id",
+        "property" : "api_name",
         "propertyValue" : "*",
         "type" : "property",
         "value" : "*"
@@ -13890,11 +12693,1871 @@
     },
     "currentUniqueKey" : 19,
     "relatedDetectors" : [ ],
-    "revisionNumber" : 30,
-    "uiHelperValue" : "##CHARTID##_30"
+    "revisionNumber" : 27,
+    "uiHelperValue" : "##CHARTID##_27"
+  }
+}, {
+  "marshallId" : 61,
+  "marshallMemberOf" : [ 59 ],
+  "sf_chart" : "Upstream Latency",
+  "sf_chartIndex" : 1528135368079,
+  "sf_description" : "Average latency for upstream responses compared with -24h average",
+  "sf_type" : "Chart",
+  "sf_uiModel" : {
+    "allPlots" : [ {
+      "_originalLabel" : "J",
+      "configuration" : {
+        "aliases" : { },
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
+        "maxExtrapolations" : -1,
+        "prefix" : "",
+        "rollupPolicy" : "LATEST_ROLLUP",
+        "suffix" : "",
+        "unitType" : "Millisecond"
+      },
+      "dataManipulations" : [ {
+        "direction" : {
+          "options" : {
+            "aggregateGroupBy" : [ {
+              "value" : "api_name"
+            } ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          },
+          "type" : "aggregation"
+        },
+        "fn" : {
+          "options" : { },
+          "type" : "SUM"
+        },
+        "showMe" : false
+      } ],
+      "invisible" : true,
+      "name" : "counter.kong.upstream.latency - Sum by api_name",
+      "queryItems" : [ {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "plugin",
+        "propertyValue" : "kong",
+        "type" : "property",
+        "value" : "kong"
+      }, {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "api_name",
+        "propertyValue" : "*",
+        "type" : "property",
+        "value" : "*"
+      } ],
+      "seriesData" : {
+        "metric" : "counter.kong.upstream.latency",
+        "regExStyle" : null
+      },
+      "transient" : false,
+      "type" : "plot",
+      "uniqueKey" : 10,
+      "yAxisIndex" : 0
+    }, {
+      "_originalLabel" : "K",
+      "configuration" : {
+        "aliases" : { },
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
+        "maxExtrapolations" : -1,
+        "rollupPolicy" : "LATEST_ROLLUP"
+      },
+      "dataManipulations" : [ {
+        "direction" : {
+          "options" : {
+            "aggregateGroupBy" : [ {
+              "value" : "api_name"
+            } ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          },
+          "type" : "aggregation"
+        },
+        "fn" : {
+          "options" : { },
+          "type" : "SUM"
+        },
+        "showMe" : false
+      } ],
+      "invisible" : true,
+      "metricDefinition" : { },
+      "name" : "counter.kong.responses.count - Sum by api_name",
+      "queryItems" : [ {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "plugin",
+        "propertyValue" : "kong",
+        "type" : "property",
+        "value" : "kong"
+      }, {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "api_name",
+        "propertyValue" : "*",
+        "type" : "property",
+        "value" : "*"
+      } ],
+      "seriesData" : {
+        "metric" : "counter.kong.responses.count",
+        "regExStyle" : null
+      },
+      "transient" : false,
+      "type" : "plot",
+      "uniqueKey" : 11,
+      "yAxisIndex" : 0
+    }, {
+      "_originalLabel" : "L",
+      "configuration" : {
+        "aliases" : { },
+        "colorOverride" : null,
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
+        "maxExtrapolations" : -1,
+        "prefix" : "",
+        "suffix" : "",
+        "unitType" : "Millisecond"
+      },
+      "dataManipulations" : [ ],
+      "expressionText" : "J / K",
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "latency",
+      "queryItems" : [ ],
+      "seriesData" : {
+        "metric" : null
+      },
+      "transient" : false,
+      "type" : "ratio",
+      "uniqueKey" : 12,
+      "valid" : true,
+      "yAxisIndex" : 0
+    }, {
+      "_originalLabel" : "O",
+      "configuration" : {
+        "aliases" : { },
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
+        "maxExtrapolations" : -1
+      },
+      "dataManipulations" : [ {
+        "direction" : {
+          "options" : {
+            "aggregateGroupBy" : [ ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          },
+          "type" : "aggregation"
+        },
+        "fn" : {
+          "options" : { },
+          "type" : "SUM"
+        },
+        "showMe" : false
+      } ],
+      "expressionText" : "J",
+      "invisible" : true,
+      "metricDefinition" : { },
+      "name" : "J - Sum",
+      "queryItems" : [ ],
+      "seriesData" : {
+        "metric" : null
+      },
+      "transient" : false,
+      "type" : "ratio",
+      "uniqueKey" : 15,
+      "valid" : true,
+      "yAxisIndex" : 0
+    }, {
+      "_originalLabel" : "P",
+      "configuration" : {
+        "aliases" : { },
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
+        "maxExtrapolations" : -1
+      },
+      "dataManipulations" : [ {
+        "direction" : {
+          "options" : {
+            "aggregateGroupBy" : [ ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          },
+          "type" : "aggregation"
+        },
+        "fn" : {
+          "options" : { },
+          "type" : "SUM"
+        },
+        "showMe" : false
+      } ],
+      "expressionText" : "K",
+      "invisible" : true,
+      "metricDefinition" : { },
+      "name" : "K - Sum",
+      "queryItems" : [ ],
+      "seriesData" : {
+        "metric" : null
+      },
+      "transient" : false,
+      "type" : "ratio",
+      "uniqueKey" : 16,
+      "valid" : true,
+      "yAxisIndex" : 0
+    }, {
+      "_originalLabel" : "Q",
+      "configuration" : {
+        "aliases" : { },
+        "colorOverride" : null,
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
+        "maxExtrapolations" : -1,
+        "prefix" : "",
+        "suffix" : "",
+        "unitType" : "Millisecond",
+        "visualization" : "line"
+      },
+      "dataManipulations" : [ {
+        "direction" : {
+          "options" : {
+            "aggregateGroupBy" : [ ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          },
+          "type" : "aggregation"
+        },
+        "fn" : {
+          "options" : {
+            "milliseconds" : 86400000
+          },
+          "type" : "TIMESHIFT"
+        },
+        "showMe" : false
+      } ],
+      "expressionText" : "O/P",
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "latency (historic)",
+      "queryItems" : [ ],
+      "seriesData" : {
+        "metric" : null
+      },
+      "transient" : false,
+      "type" : "ratio",
+      "uniqueKey" : 17,
+      "valid" : true,
+      "yAxisIndex" : 1
+    }, {
+      "configuration" : {
+        "aliases" : { },
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
+        "maxExtrapolations" : -1
+      },
+      "dataManipulations" : [ ],
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "New Plot",
+      "queryItems" : [ ],
+      "seriesData" : { },
+      "transient" : true,
+      "type" : "plot",
+      "uniqueKey" : 18,
+      "yAxisIndex" : 0
+    } ],
+    "chartMode" : "graph",
+    "chartType" : "heatmap",
+    "chartconfig" : {
+      "absoluteEnd" : null,
+      "absoluteStart" : null,
+      "colorByMetric" : false,
+      "colorByValue" : false,
+      "colorByValueScale" : [ ],
+      "histogramColor" : "#a747ff",
+      "range" : -1800000,
+      "rangeEnd" : 0,
+      "secondaryVisualization" : "SPARKLINE",
+      "sortPreference" : "-value",
+      "stackedChart" : false,
+      "useKMG2" : false,
+      "yAxisConfigurations" : [ {
+        "id" : "yAxis0",
+        "label" : "latency/resp",
+        "max" : null,
+        "min" : null,
+        "name" : "yAxis0",
+        "plotlines" : {
+          "high" : null,
+          "low" : null
+        }
+      }, {
+        "label" : "latency/resp",
+        "max" : null,
+        "min" : null,
+        "plotlines" : {
+          "high" : null,
+          "low" : null
+        },
+        "title" : {
+          "text" : ""
+        }
+      } ]
+    },
+    "currentUniqueKey" : 19,
+    "relatedDetectors" : [ ],
+    "revisionNumber" : 33,
+    "uiHelperValue" : "##CHARTID##_33"
+  }
+}, {
+  "marshallId" : 62,
+  "marshallMemberOf" : [ 59 ],
+  "sf_chart" : "Requests by HTTP Method",
+  "sf_chartIndex" : 1528138165800,
+  "sf_description" : "Number of API-fielded requests per interval by HTTP method",
+  "sf_type" : "Chart",
+  "sf_uiModel" : {
+    "allPlots" : [ {
+      "_originalLabel" : "A",
+      "configuration" : {
+        "aliases" : { },
+        "colorOverride" : null,
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
+        "maxExtrapolations" : -1,
+        "rollupPolicy" : "DELTA_ROLLUP",
+        "suffix" : "requests",
+        "unitType" : null
+      },
+      "dataManipulations" : [ {
+        "direction" : {
+          "options" : {
+            "aggregateGroupBy" : [ {
+              "value" : "http_method"
+            } ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          },
+          "type" : "aggregation"
+        },
+        "fn" : {
+          "options" : { },
+          "type" : "SUM"
+        },
+        "showMe" : false
+      } ],
+      "invisible" : false,
+      "name" : "counter.kong.responses.count - Sum by http_method",
+      "queryItems" : [ {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "plugin",
+        "propertyValue" : "kong",
+        "type" : "property",
+        "value" : "kong"
+      }, {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "api_name",
+        "propertyValue" : "*",
+        "type" : "property",
+        "value" : "*"
+      } ],
+      "seriesData" : {
+        "metric" : "counter.kong.responses.count"
+      },
+      "transient" : false,
+      "type" : "plot",
+      "uniqueKey" : 1,
+      "yAxisIndex" : 0
+    }, {
+      "configuration" : {
+        "aliases" : { },
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
+        "maxExtrapolations" : -1
+      },
+      "dataManipulations" : [ ],
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "New Plot",
+      "queryItems" : [ ],
+      "seriesData" : { },
+      "transient" : true,
+      "type" : "plot",
+      "uniqueKey" : 18,
+      "yAxisIndex" : 0
+    } ],
+    "chartMode" : "graph",
+    "chartType" : "column",
+    "chartconfig" : {
+      "absoluteEnd" : null,
+      "absoluteStart" : null,
+      "colorByMetric" : false,
+      "colorByValue" : false,
+      "colorByValueScale" : [ ],
+      "histogramColor" : "#ea1849",
+      "maxDecimalPlaces" : 4,
+      "range" : -1800000,
+      "rangeEnd" : 0,
+      "secondaryVisualization" : "SPARKLINE",
+      "sortPreference" : "+http_method",
+      "stackedChart" : true,
+      "useKMG2" : false,
+      "yAxisConfigurations" : [ {
+        "id" : "yAxis0",
+        "label" : "req/intvl",
+        "max" : null,
+        "min" : null,
+        "name" : "yAxis0",
+        "plotlines" : {
+          "high" : null,
+          "low" : null
+        }
+      } ]
+    },
+    "currentUniqueKey" : 19,
+    "relatedDetectors" : [ ],
+    "revisionNumber" : 28,
+    "uiHelperValue" : "##CHARTID##_28"
+  }
+}, {
+  "marshallId" : 63,
+  "marshallMemberOf" : [ 59 ],
+  "sf_chart" : "Responses / Second",
+  "sf_chartIndex" : 1528134810674,
+  "sf_description" : "Rate of API responses",
+  "sf_type" : "Chart",
+  "sf_uiModel" : {
+    "allPlots" : [ {
+      "_originalLabel" : "A",
+      "configuration" : {
+        "aliases" : { },
+        "colorOverride" : "#0077c2",
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
+        "maxExtrapolations" : -1,
+        "prefix" : "",
+        "suffix" : "",
+        "unitType" : null
+      },
+      "dataManipulations" : [ {
+        "direction" : {
+          "options" : {
+            "aggregateGroupBy" : [ ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          },
+          "type" : "aggregation"
+        },
+        "fn" : {
+          "options" : { },
+          "type" : "SUM"
+        },
+        "showMe" : false
+      } ],
+      "invisible" : false,
+      "name" : "responses",
+      "queryItems" : [ {
+        "NOT" : false,
+        "iconClass" : "sf-icon-property",
+        "property" : "plugin",
+        "propertyValue" : "kong",
+        "query" : "plugin:\"kong\"",
+        "type" : "property",
+        "value" : "kong"
+      }, {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "api_name",
+        "propertyValue" : "*",
+        "type" : "property",
+        "value" : "*"
+      } ],
+      "seriesData" : {
+        "metric" : "counter.kong.responses.count"
+      },
+      "transient" : false,
+      "type" : "plot",
+      "uniqueKey" : 1,
+      "yAxisIndex" : 0
+    }, {
+      "configuration" : {
+        "aliases" : { },
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
+        "maxExtrapolations" : -1
+      },
+      "dataManipulations" : [ ],
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "New Plot",
+      "queryItems" : [ ],
+      "seriesData" : { },
+      "transient" : true,
+      "type" : "plot",
+      "uniqueKey" : 2,
+      "yAxisIndex" : 0
+    } ],
+    "chartMode" : "single",
+    "chartType" : "line",
+    "chartconfig" : {
+      "absoluteEnd" : null,
+      "absoluteStart" : null,
+      "colorByMetric" : false,
+      "colorByValue" : false,
+      "colorByValueScale" : [ ],
+      "hideTimestamp" : false,
+      "histogramColor" : "#ea1849",
+      "maxDecimalPlaces" : 2,
+      "range" : -1800000,
+      "rangeEnd" : 0,
+      "secondaryVisualization" : "NONE",
+      "sortPreference" : "",
+      "useKMG2" : false,
+      "yAxisConfigurations" : [ {
+        "id" : "yAxis0",
+        "max" : null,
+        "min" : null,
+        "name" : "yAxis0",
+        "plotlines" : {
+          "high" : null,
+          "low" : null
+        }
+      } ]
+    },
+    "currentUniqueKey" : 3,
+    "relatedDetectors" : [ ],
+    "revisionNumber" : 20,
+    "uiHelperValue" : "##CHARTID##_20"
+  }
+}, {
+  "marshallId" : 64,
+  "marshallMemberOf" : [ 59 ],
+  "sf_chart" : "Request Size",
+  "sf_chartIndex" : 1528146664212,
+  "sf_description" : "Average size of API-fielded client requests compared with -24h average",
+  "sf_type" : "Chart",
+  "sf_uiModel" : {
+    "allPlots" : [ {
+      "_originalLabel" : "K",
+      "configuration" : {
+        "aliases" : { },
+        "colorOverride" : null,
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
+        "maxExtrapolations" : -1,
+        "prefix" : "",
+        "rollupPolicy" : null,
+        "suffix" : "",
+        "unitType" : "Byte",
+        "visualization" : null
+      },
+      "dataManipulations" : [ {
+        "direction" : {
+          "options" : {
+            "aggregateGroupBy" : [ {
+              "value" : "api_name"
+            } ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          },
+          "type" : "aggregation"
+        },
+        "fn" : {
+          "options" : { },
+          "type" : "SUM"
+        },
+        "showMe" : false
+      } ],
+      "invisible" : true,
+      "name" : "counter.kong.requests.size - Sum by api_name",
+      "queryItems" : [ {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "plugin",
+        "propertyValue" : "kong",
+        "type" : "property",
+        "value" : "kong"
+      }, {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "api_name",
+        "propertyValue" : "*",
+        "type" : "property",
+        "value" : "*"
+      } ],
+      "seriesData" : {
+        "metric" : "counter.kong.requests.size",
+        "regExStyle" : null
+      },
+      "transient" : false,
+      "type" : "plot",
+      "uniqueKey" : 11,
+      "yAxisIndex" : 0
+    }, {
+      "_originalLabel" : "L",
+      "configuration" : {
+        "aliases" : { },
+        "colorOverride" : null,
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
+        "maxExtrapolations" : -1,
+        "prefix" : "",
+        "rollupPolicy" : null,
+        "suffix" : "",
+        "unitType" : "Byte"
+      },
+      "dataManipulations" : [ {
+        "direction" : {
+          "options" : {
+            "aggregateGroupBy" : [ {
+              "value" : "api_name"
+            } ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          },
+          "type" : "aggregation"
+        },
+        "fn" : {
+          "options" : { },
+          "type" : "SUM"
+        },
+        "showMe" : false
+      } ],
+      "invisible" : true,
+      "name" : "counter.kong.responses.count - Sum by api_name",
+      "queryItems" : [ {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "plugin",
+        "propertyValue" : "kong",
+        "type" : "property",
+        "value" : "kong"
+      }, {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "api_name",
+        "propertyValue" : "*",
+        "type" : "property",
+        "value" : "*"
+      } ],
+      "seriesData" : {
+        "metric" : "counter.kong.responses.count",
+        "regExStyle" : null
+      },
+      "transient" : false,
+      "type" : "plot",
+      "uniqueKey" : 12,
+      "yAxisIndex" : 0
+    }, {
+      "_originalLabel" : "M",
+      "configuration" : {
+        "aliases" : { },
+        "colorOverride" : null,
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
+        "maxExtrapolations" : -1,
+        "prefix" : "",
+        "suffix" : "",
+        "unitType" : "Byte"
+      },
+      "dataManipulations" : [ ],
+      "expressionText" : "K/L",
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "request size",
+      "queryItems" : [ ],
+      "seriesData" : {
+        "metric" : null
+      },
+      "transient" : false,
+      "type" : "ratio",
+      "uniqueKey" : 13,
+      "valid" : true,
+      "yAxisIndex" : 0
+    }, {
+      "_originalLabel" : "P",
+      "configuration" : {
+        "aliases" : { },
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
+        "maxExtrapolations" : -1
+      },
+      "dataManipulations" : [ {
+        "direction" : {
+          "options" : {
+            "aggregateGroupBy" : [ ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          },
+          "type" : "aggregation"
+        },
+        "fn" : {
+          "options" : { },
+          "type" : "SUM"
+        },
+        "showMe" : false
+      } ],
+      "expressionText" : "K",
+      "invisible" : true,
+      "metricDefinition" : { },
+      "name" : "K - Sum",
+      "queryItems" : [ ],
+      "seriesData" : {
+        "metric" : null
+      },
+      "transient" : false,
+      "type" : "ratio",
+      "uniqueKey" : 16,
+      "valid" : true,
+      "yAxisIndex" : 0
+    }, {
+      "_originalLabel" : "Q",
+      "configuration" : {
+        "aliases" : { },
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
+        "maxExtrapolations" : -1
+      },
+      "dataManipulations" : [ {
+        "direction" : {
+          "options" : {
+            "aggregateGroupBy" : [ ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          },
+          "type" : "aggregation"
+        },
+        "fn" : {
+          "options" : { },
+          "type" : "SUM"
+        },
+        "showMe" : false
+      } ],
+      "expressionText" : "L",
+      "invisible" : true,
+      "metricDefinition" : { },
+      "name" : "L - Sum",
+      "queryItems" : [ ],
+      "seriesData" : {
+        "metric" : null
+      },
+      "transient" : false,
+      "type" : "ratio",
+      "uniqueKey" : 17,
+      "valid" : true,
+      "yAxisIndex" : 0
+    }, {
+      "_originalLabel" : "R",
+      "configuration" : {
+        "aliases" : { },
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
+        "maxExtrapolations" : -1,
+        "prefix" : "",
+        "suffix" : "",
+        "unitType" : "Byte",
+        "visualization" : "line"
+      },
+      "dataManipulations" : [ {
+        "direction" : {
+          "options" : {
+            "aggregateGroupBy" : [ ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          },
+          "type" : "aggregation"
+        },
+        "fn" : {
+          "options" : {
+            "milliseconds" : 86400000
+          },
+          "type" : "TIMESHIFT"
+        },
+        "showMe" : false
+      } ],
+      "expressionText" : "P/Q",
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "request size (historic)",
+      "queryItems" : [ ],
+      "seriesData" : {
+        "metric" : null
+      },
+      "transient" : false,
+      "type" : "ratio",
+      "uniqueKey" : 18,
+      "valid" : true,
+      "yAxisIndex" : 1
+    }, {
+      "configuration" : {
+        "aliases" : { },
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
+        "maxExtrapolations" : -1
+      },
+      "dataManipulations" : [ ],
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "New Plot",
+      "queryItems" : [ ],
+      "seriesData" : { },
+      "transient" : true,
+      "type" : "plot",
+      "uniqueKey" : 19,
+      "yAxisIndex" : 0
+    } ],
+    "chartMode" : "graph",
+    "chartType" : "heatmap",
+    "chartconfig" : {
+      "absoluteEnd" : null,
+      "absoluteStart" : null,
+      "colorByMetric" : false,
+      "colorByValue" : false,
+      "colorByValueScale" : [ ],
+      "dimensionInLegend" : "sf_metric",
+      "eventLines" : false,
+      "histogramColor" : "#0dba8f",
+      "includeZero" : false,
+      "range" : -1800000,
+      "rangeEnd" : 0,
+      "secondaryVisualization" : "SPARKLINE",
+      "showLegend" : false,
+      "sortPreference" : "-value",
+      "useKMG2" : false,
+      "yAxisConfigurations" : [ {
+        "id" : "yAxis0",
+        "label" : "bytes/req",
+        "max" : null,
+        "min" : null,
+        "name" : "yAxis0",
+        "plotlines" : {
+          "high" : null,
+          "low" : null
+        }
+      }, {
+        "label" : "bytes/req",
+        "max" : null,
+        "min" : null,
+        "plotlines" : {
+          "high" : null,
+          "low" : null
+        },
+        "title" : {
+          "text" : ""
+        }
+      } ]
+    },
+    "currentUniqueKey" : 20,
+    "relatedDetectors" : [ ],
+    "revisionNumber" : 33,
+    "uiHelperValue" : "##CHARTID##_33"
+  }
+}, {
+  "marshallId" : 65,
+  "marshallMemberOf" : [ 59 ],
+  "sf_chart" : "Responses / Second",
+  "sf_chartIndex" : 1528219376990,
+  "sf_description" : "Rate of upstream responses compared with -24h",
+  "sf_type" : "Chart",
+  "sf_uiModel" : {
+    "allPlots" : [ {
+      "_originalLabel" : "B",
+      "configuration" : {
+        "aliases" : { },
+        "colorOverride" : null,
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
+        "maxExtrapolations" : -1,
+        "prefix" : "",
+        "suffix" : "responses",
+        "unitType" : null
+      },
+      "dataManipulations" : [ {
+        "direction" : {
+          "options" : {
+            "aggregateGroupBy" : [ {
+              "value" : "api_name"
+            } ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          },
+          "type" : "aggregation"
+        },
+        "fn" : {
+          "options" : { },
+          "type" : "SUM"
+        },
+        "showMe" : false
+      } ],
+      "invisible" : false,
+      "name" : "",
+      "queryItems" : [ {
+        "NOT" : false,
+        "iconClass" : "sf-icon-property",
+        "property" : "plugin",
+        "propertyValue" : "kong",
+        "query" : "plugin:\"kong\"",
+        "type" : "property",
+        "value" : "kong"
+      }, {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "api_name",
+        "propertyValue" : "*",
+        "type" : "property",
+        "value" : "*"
+      } ],
+      "seriesData" : {
+        "metric" : "counter.kong.responses.count"
+      },
+      "transient" : false,
+      "type" : "plot",
+      "uniqueKey" : 2,
+      "yAxisIndex" : 0
+    }, {
+      "_originalLabel" : "C",
+      "configuration" : {
+        "aliases" : { },
+        "colorOverride" : "#b04600",
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
+        "maxExtrapolations" : -1,
+        "suffix" : "responses",
+        "unitType" : null,
+        "visualization" : "line"
+      },
+      "dataManipulations" : [ {
+        "direction" : {
+          "options" : {
+            "aggregateGroupBy" : [ ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          },
+          "type" : "aggregation"
+        },
+        "fn" : {
+          "options" : { },
+          "type" : "SUM"
+        },
+        "showMe" : false
+      }, {
+        "direction" : {
+          "options" : {
+            "aggregateGroupBy" : [ ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          },
+          "type" : "aggregation"
+        },
+        "fn" : {
+          "options" : {
+            "milliseconds" : 86400000
+          },
+          "type" : "TIMESHIFT"
+        },
+        "showMe" : false
+      } ],
+      "expressionText" : "B",
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "(historic)",
+      "queryItems" : [ ],
+      "seriesData" : {
+        "metric" : null
+      },
+      "transient" : false,
+      "type" : "ratio",
+      "uniqueKey" : 3,
+      "valid" : true,
+      "yAxisIndex" : 1
+    }, {
+      "configuration" : {
+        "aliases" : { },
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
+        "maxExtrapolations" : -1
+      },
+      "dataManipulations" : [ ],
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "New Plot",
+      "queryItems" : [ ],
+      "seriesData" : { },
+      "transient" : true,
+      "type" : "plot",
+      "uniqueKey" : 4,
+      "yAxisIndex" : 0
+    } ],
+    "chartMode" : "graph",
+    "chartType" : "area",
+    "chartconfig" : {
+      "absoluteEnd" : null,
+      "absoluteStart" : null,
+      "colorByMetric" : false,
+      "colorByValue" : false,
+      "colorByValueScale" : [ ],
+      "dimensionInLegend" : "api_name",
+      "hideTimestamp" : false,
+      "histogramColor" : "#ea1849",
+      "maxDecimalPlaces" : 2,
+      "range" : -1800000,
+      "rangeEnd" : 0,
+      "secondaryVisualization" : "NONE",
+      "showLegend" : false,
+      "sortPreference" : "",
+      "stackedChart" : true,
+      "useKMG2" : false,
+      "yAxisConfigurations" : [ {
+        "id" : "yAxis0",
+        "label" : "resp/s",
+        "max" : null,
+        "min" : null,
+        "name" : "yAxis0",
+        "plotlines" : {
+          "high" : null,
+          "low" : null
+        }
+      }, {
+        "label" : "resp/s",
+        "max" : null,
+        "min" : null,
+        "plotlines" : {
+          "high" : null,
+          "low" : null
+        },
+        "title" : {
+          "text" : ""
+        }
+      } ]
+    },
+    "currentUniqueKey" : 5,
+    "relatedDetectors" : [ ],
+    "revisionNumber" : 36,
+    "uiHelperValue" : "##CHARTID##_36"
+  }
+}, {
+  "marshallId" : 66,
+  "marshallMemberOf" : [ 59 ],
+  "sf_chart" : "4xx Responses by HTTP Method",
+  "sf_chartIndex" : 1528312603879,
+  "sf_description" : "Number of 4xx errors per interval by HTTP method",
+  "sf_type" : "Chart",
+  "sf_uiModel" : {
+    "allPlots" : [ {
+      "_originalLabel" : "A",
+      "configuration" : {
+        "aliases" : { },
+        "colorOverride" : null,
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
+        "maxExtrapolations" : -1,
+        "rollupPolicy" : "DELTA_ROLLUP",
+        "suffix" : "errors",
+        "unitType" : null
+      },
+      "dataManipulations" : [ {
+        "direction" : {
+          "options" : {
+            "aggregateGroupBy" : [ {
+              "value" : "http_method"
+            }, {
+              "value" : "status_code"
+            } ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          },
+          "type" : "aggregation"
+        },
+        "fn" : {
+          "options" : { },
+          "type" : "SUM"
+        },
+        "showMe" : false
+      } ],
+      "invisible" : false,
+      "name" : "errors",
+      "queryItems" : [ {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "plugin",
+        "propertyValue" : "kong",
+        "type" : "property",
+        "value" : "kong"
+      }, {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "api_name",
+        "propertyValue" : "*",
+        "type" : "property",
+        "value" : "*"
+      }, {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "status_code",
+        "propertyValue" : "4*",
+        "type" : "property",
+        "value" : "201"
+      } ],
+      "seriesData" : {
+        "metric" : "counter.kong.responses.count",
+        "regExStyle" : null
+      },
+      "transient" : false,
+      "type" : "plot",
+      "uniqueKey" : 1,
+      "yAxisIndex" : 0
+    }, {
+      "configuration" : {
+        "aliases" : { },
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
+        "maxExtrapolations" : -1
+      },
+      "dataManipulations" : [ ],
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "New Plot",
+      "queryItems" : [ ],
+      "seriesData" : { },
+      "transient" : true,
+      "type" : "plot",
+      "uniqueKey" : 18,
+      "yAxisIndex" : 0
+    } ],
+    "chartMode" : "graph",
+    "chartType" : "column",
+    "chartconfig" : {
+      "absoluteEnd" : null,
+      "absoluteStart" : null,
+      "colorByMetric" : false,
+      "colorByValue" : false,
+      "colorByValueScale" : [ ],
+      "groupBy" : [ ],
+      "heatmapAutoGradients" : 5,
+      "heatmapColorRange" : { },
+      "heatmapSortBy" : {
+        "asc" : true,
+        "value" : { }
+      },
+      "heatmapUnitsPerRow" : 0,
+      "heatmapUseValueAsColor" : false,
+      "hideTimestamp" : false,
+      "histogramColor" : "#ea1849",
+      "maxDecimalPlaces" : 4,
+      "range" : -900000,
+      "rangeEnd" : 0,
+      "secondaryVisualization" : "SPARKLINE",
+      "sortPreference" : "",
+      "stackedChart" : true,
+      "useKMG2" : false,
+      "yAxisConfigurations" : [ {
+        "id" : "yAxis0",
+        "label" : "errors/intvl",
+        "max" : null,
+        "min" : null,
+        "name" : "yAxis0",
+        "plotlines" : {
+          "high" : null,
+          "low" : null
+        }
+      } ]
+    },
+    "currentUniqueKey" : 19,
+    "relatedDetectors" : [ ],
+    "revisionNumber" : 31,
+    "uiHelperValue" : "##CHARTID##_31"
   }
 }, {
   "marshallId" : 67,
+  "marshallMemberOf" : [ 59 ],
+  "sf_chart" : "Responses",
+  "sf_chartIndex" : 1528304230699,
+  "sf_description" : "Within past hour",
+  "sf_type" : "Chart",
+  "sf_uiModel" : {
+    "allPlots" : [ {
+      "_originalLabel" : "A",
+      "configuration" : {
+        "aliases" : { },
+        "colorOverride" : null,
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
+        "maxExtrapolations" : -1,
+        "prefix" : "",
+        "rollupPolicy" : "SUM_ROLLUP",
+        "suffix" : "",
+        "unitType" : null
+      },
+      "dataManipulations" : [ {
+        "direction" : {
+          "options" : {
+            "aggregateGroupBy" : [ ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          },
+          "type" : "aggregation"
+        },
+        "fn" : {
+          "options" : { },
+          "type" : "SUM"
+        },
+        "showMe" : false
+      } ],
+      "invisible" : true,
+      "name" : "counter.kong.responses.count - Sum",
+      "queryItems" : [ {
+        "NOT" : false,
+        "iconClass" : "sf-icon-property",
+        "property" : "plugin",
+        "propertyValue" : "kong",
+        "query" : "plugin:\"kong\"",
+        "type" : "property",
+        "value" : "kong"
+      }, {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "api_name",
+        "propertyValue" : "*",
+        "type" : "property",
+        "value" : "*"
+      } ],
+      "seriesData" : {
+        "metric" : "counter.kong.responses.count"
+      },
+      "transient" : false,
+      "type" : "plot",
+      "uniqueKey" : 1,
+      "yAxisIndex" : 0
+    }, {
+      "_originalLabel" : "B",
+      "configuration" : {
+        "aliases" : { },
+        "colorOverride" : null,
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
+        "maxExtrapolations" : -1,
+        "prefix" : "",
+        "rollupPolicy" : "SUM_ROLLUP",
+        "suffix" : "",
+        "unitType" : null
+      },
+      "dataManipulations" : [ {
+        "direction" : {
+          "options" : {
+            "aggregateGroupBy" : [ ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          },
+          "type" : "aggregation"
+        },
+        "fn" : {
+          "options" : {
+            "milliseconds" : 3600000
+          },
+          "type" : "TIMESHIFT"
+        },
+        "showMe" : false
+      }, {
+        "direction" : {
+          "options" : {
+            "aggregateGroupBy" : [ ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          },
+          "type" : "aggregation"
+        },
+        "fn" : {
+          "options" : { },
+          "type" : "SUM"
+        },
+        "showMe" : false
+      } ],
+      "invisible" : true,
+      "name" : "counter.kong.responses.count - Timeshift 1h - Sum",
+      "queryItems" : [ {
+        "NOT" : false,
+        "iconClass" : "sf-icon-property",
+        "property" : "plugin",
+        "propertyValue" : "kong",
+        "query" : "plugin:\"kong\"",
+        "type" : "property",
+        "value" : "kong"
+      }, {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "api_name",
+        "propertyValue" : "*",
+        "type" : "property",
+        "value" : "*"
+      } ],
+      "seriesData" : {
+        "metric" : "counter.kong.responses.count"
+      },
+      "transient" : false,
+      "type" : "plot",
+      "uniqueKey" : 2,
+      "yAxisIndex" : 0
+    }, {
+      "_originalLabel" : "C",
+      "configuration" : {
+        "aliases" : { },
+        "colorOverride" : "#00b9ff",
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
+        "maxExtrapolations" : -1
+      },
+      "dataManipulations" : [ {
+        "direction" : {
+          "options" : {
+            "aggregateGroupBy" : [ ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          },
+          "type" : "aggregation"
+        },
+        "fn" : {
+          "options" : {
+            "action" : "drop",
+            "inclusive" : true,
+            "low" : 0,
+            "mode" : "below"
+          },
+          "type" : "EXCLUDE"
+        },
+        "showMe" : false
+      } ],
+      "expressionText" : "A-B",
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "within past hour",
+      "queryItems" : [ ],
+      "seriesData" : {
+        "metric" : null
+      },
+      "transient" : false,
+      "type" : "ratio",
+      "uniqueKey" : 3,
+      "valid" : true,
+      "yAxisIndex" : 0
+    }, {
+      "configuration" : {
+        "aliases" : { },
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
+        "maxExtrapolations" : -1
+      },
+      "dataManipulations" : [ ],
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "New Plot",
+      "queryItems" : [ ],
+      "seriesData" : { },
+      "transient" : true,
+      "type" : "plot",
+      "uniqueKey" : 4,
+      "yAxisIndex" : 0
+    } ],
+    "chartMode" : "single",
+    "chartType" : "line",
+    "chartconfig" : {
+      "absoluteEnd" : null,
+      "absoluteStart" : null,
+      "colorByMetric" : false,
+      "colorByValue" : false,
+      "colorByValueScale" : [ ],
+      "hideTimestamp" : false,
+      "histogramColor" : "#ea1849",
+      "maxDecimalPlaces" : 2,
+      "range" : -1800000,
+      "rangeEnd" : 0,
+      "secondaryVisualization" : "NONE",
+      "sortPreference" : "",
+      "useKMG2" : false,
+      "yAxisConfigurations" : [ {
+        "id" : "yAxis0",
+        "max" : null,
+        "min" : null,
+        "name" : "yAxis0",
+        "plotlines" : {
+          "high" : null,
+          "low" : null
+        }
+      } ]
+    },
+    "currentUniqueKey" : 5,
+    "relatedDetectors" : [ ],
+    "revisionNumber" : 24,
+    "uiHelperValue" : "##CHARTID##_24"
+  }
+}, {
+  "marshallId" : 68,
+  "marshallMemberOf" : [ 59 ],
+  "sf_chart" : "Responses by Status Code",
+  "sf_chartIndex" : 1528136271804,
+  "sf_description" : "Number of responses per interval by status code group",
+  "sf_type" : "Chart",
+  "sf_uiModel" : {
+    "allPlots" : [ {
+      "_originalLabel" : "E",
+      "configuration" : {
+        "aliases" : { },
+        "colorOverride" : "#999999",
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
+        "maxExtrapolations" : -1,
+        "rollupPolicy" : "SUM_ROLLUP",
+        "suffix" : "responses",
+        "unitType" : null
+      },
+      "dataManipulations" : [ {
+        "direction" : {
+          "options" : {
+            "aggregateGroupBy" : [ ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          },
+          "type" : "aggregation"
+        },
+        "fn" : {
+          "options" : { },
+          "type" : "SUM"
+        },
+        "showMe" : false
+      } ],
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "1xx",
+      "queryItems" : [ {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "isSynthetic" : true,
+        "property" : "plugin",
+        "propertyValue" : "kong",
+        "type" : "property",
+        "value" : "kong"
+      }, {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "status_code",
+        "propertyValue" : "1*",
+        "type" : "property",
+        "value" : "1*"
+      }, {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "api_name",
+        "propertyValue" : "*",
+        "type" : "property",
+        "value" : "*"
+      } ],
+      "seriesData" : {
+        "metric" : "counter.kong.responses.count",
+        "regExStyle" : null
+      },
+      "transient" : false,
+      "type" : "plot",
+      "uniqueKey" : 5,
+      "yAxisIndex" : 0
+    }, {
+      "_originalLabel" : "A",
+      "configuration" : {
+        "aliases" : { },
+        "colorOverride" : "#00b9ff",
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
+        "maxExtrapolations" : -1,
+        "rollupPolicy" : "DELTA_ROLLUP",
+        "suffix" : "responses",
+        "unitType" : null
+      },
+      "dataManipulations" : [ {
+        "direction" : {
+          "options" : {
+            "aggregateGroupBy" : [ ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          },
+          "type" : "aggregation"
+        },
+        "fn" : {
+          "options" : { },
+          "type" : "SUM"
+        },
+        "showMe" : false
+      } ],
+      "invisible" : false,
+      "name" : "2xx",
+      "queryItems" : [ {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "plugin",
+        "propertyValue" : "kong",
+        "type" : "property",
+        "value" : "kong"
+      }, {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "status_code",
+        "propertyValue" : "2*",
+        "type" : "property",
+        "value" : "2*"
+      }, {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "api_name",
+        "propertyValue" : "*",
+        "type" : "property",
+        "value" : "*"
+      } ],
+      "seriesData" : {
+        "metric" : "counter.kong.responses.count"
+      },
+      "transient" : false,
+      "type" : "plot",
+      "uniqueKey" : 1,
+      "yAxisIndex" : 0
+    }, {
+      "_originalLabel" : "C",
+      "configuration" : {
+        "aliases" : { },
+        "colorOverride" : "#e5b312",
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
+        "maxExtrapolations" : -1,
+        "rollupPolicy" : "DELTA_ROLLUP",
+        "suffix" : "responses",
+        "unitType" : null
+      },
+      "dataManipulations" : [ {
+        "direction" : {
+          "options" : {
+            "aggregateGroupBy" : [ ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          },
+          "type" : "aggregation"
+        },
+        "fn" : {
+          "options" : { },
+          "type" : "SUM"
+        },
+        "showMe" : false
+      } ],
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "3xx",
+      "queryItems" : [ {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "plugin",
+        "propertyValue" : "kong",
+        "type" : "property",
+        "value" : "kong"
+      }, {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "status_code",
+        "propertyValue" : "3*",
+        "type" : "property",
+        "value" : "3*"
+      }, {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "api_name",
+        "propertyValue" : "*",
+        "type" : "property",
+        "value" : "*"
+      } ],
+      "seriesData" : {
+        "metric" : "counter.kong.responses.count",
+        "regExStyle" : null
+      },
+      "transient" : false,
+      "type" : "plot",
+      "uniqueKey" : 3,
+      "yAxisIndex" : 0
+    }, {
+      "_originalLabel" : "B",
+      "configuration" : {
+        "aliases" : { },
+        "colorOverride" : "#b04600",
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
+        "maxExtrapolations" : -1,
+        "rollupPolicy" : "DELTA_ROLLUP",
+        "suffix" : "responses",
+        "unitType" : null
+      },
+      "dataManipulations" : [ {
+        "direction" : {
+          "options" : {
+            "aggregateGroupBy" : [ ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          },
+          "type" : "aggregation"
+        },
+        "fn" : {
+          "options" : { },
+          "type" : "SUM"
+        },
+        "showMe" : false
+      } ],
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "4xx",
+      "queryItems" : [ {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "plugin",
+        "propertyValue" : "kong",
+        "type" : "property",
+        "value" : "kong"
+      }, {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "status_code",
+        "propertyValue" : "4*",
+        "type" : "property",
+        "value" : "4*"
+      }, {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "api_name",
+        "propertyValue" : "*",
+        "type" : "property",
+        "value" : "*"
+      } ],
+      "seriesData" : {
+        "metric" : "counter.kong.responses.count",
+        "regExStyle" : null
+      },
+      "transient" : false,
+      "type" : "plot",
+      "uniqueKey" : 2,
+      "yAxisIndex" : 0
+    }, {
+      "_originalLabel" : "D",
+      "configuration" : {
+        "aliases" : { },
+        "colorOverride" : "#e9008a",
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
+        "maxExtrapolations" : -1,
+        "rollupPolicy" : "DELTA_ROLLUP",
+        "suffix" : "responses",
+        "unitType" : null
+      },
+      "dataManipulations" : [ {
+        "direction" : {
+          "options" : {
+            "aggregateGroupBy" : [ ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          },
+          "type" : "aggregation"
+        },
+        "fn" : {
+          "options" : { },
+          "type" : "SUM"
+        },
+        "showMe" : false
+      } ],
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "5xx",
+      "queryItems" : [ {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "plugin",
+        "propertyValue" : "kong",
+        "type" : "property",
+        "value" : "kong"
+      }, {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "status_code",
+        "propertyValue" : "5*",
+        "type" : "property",
+        "value" : "5*"
+      }, {
+        "property" : "api_name",
+        "propertyValue" : "*",
+        "type" : "property"
+      } ],
+      "seriesData" : {
+        "metric" : "counter.kong.responses.count",
+        "regExStyle" : null
+      },
+      "transient" : false,
+      "type" : "plot",
+      "uniqueKey" : 4,
+      "yAxisIndex" : 0
+    }, {
+      "configuration" : {
+        "aliases" : { },
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
+        "maxExtrapolations" : -1
+      },
+      "dataManipulations" : [ ],
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "New Plot",
+      "queryItems" : [ ],
+      "seriesData" : { },
+      "transient" : true,
+      "type" : "plot",
+      "uniqueKey" : 11,
+      "yAxisIndex" : 0
+    } ],
+    "chartMode" : "graph",
+    "chartType" : "area",
+    "chartconfig" : {
+      "absoluteEnd" : null,
+      "absoluteStart" : null,
+      "colorByMetric" : false,
+      "dimensionInLegend" : "sf_metric",
+      "groupBy" : [ ],
+      "heatmapAutoGradients" : 5,
+      "heatmapColorRange" : { },
+      "heatmapSortBy" : {
+        "asc" : true,
+        "value" : { }
+      },
+      "heatmapUnitsPerRow" : 0,
+      "heatmapUseValueAsColor" : false,
+      "hideTimestamp" : false,
+      "histogramColor" : "#ea1849",
+      "legendColumnConfiguration" : null,
+      "range" : -1800000,
+      "rangeEnd" : 0,
+      "secondaryVisualization" : "NONE",
+      "showLegend" : true,
+      "sortPreference" : "",
+      "stackedChart" : true,
+      "useKMG2" : false,
+      "yAxisConfigurations" : [ {
+        "id" : "yAxis0",
+        "label" : "resp/intvl",
+        "max" : null,
+        "min" : null,
+        "name" : "yAxis0",
+        "plotlines" : {
+          "high" : null,
+          "low" : null
+        }
+      } ]
+    },
+    "currentUniqueKey" : 12,
+    "relatedDetectors" : [ ],
+    "revisionNumber" : 23,
+    "uiHelperValue" : "##CHARTID##_23"
+  }
+}, {
+  "marshallId" : 69,
+  "marshallMemberOf" : [ 59 ],
+  "sf_chart" : "5xx Responses by HTTP Method",
+  "sf_chartIndex" : 1528313719962,
+  "sf_description" : "Number of 5xx errors per interval by HTTP method",
+  "sf_type" : "Chart",
+  "sf_uiModel" : {
+    "allPlots" : [ {
+      "_originalLabel" : "A",
+      "configuration" : {
+        "aliases" : { },
+        "colorOverride" : null,
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
+        "maxExtrapolations" : -1,
+        "rollupPolicy" : "DELTA_ROLLUP",
+        "suffix" : "errors",
+        "unitType" : null
+      },
+      "dataManipulations" : [ {
+        "direction" : {
+          "options" : {
+            "aggregateGroupBy" : [ {
+              "value" : "http_method"
+            }, {
+              "value" : "status_code"
+            } ],
+            "collapseGroups" : false,
+            "transformTimeRange" : null
+          },
+          "type" : "aggregation"
+        },
+        "fn" : {
+          "options" : { },
+          "type" : "SUM"
+        },
+        "showMe" : false
+      } ],
+      "invisible" : false,
+      "name" : "errors",
+      "queryItems" : [ {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "plugin",
+        "propertyValue" : "kong",
+        "type" : "property",
+        "value" : "kong"
+      }, {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "api_name",
+        "propertyValue" : "*",
+        "type" : "property",
+        "value" : "*"
+      }, {
+        "NOT" : false,
+        "iconClass" : "icon-properties",
+        "property" : "status_code",
+        "propertyValue" : "5*",
+        "type" : "property",
+        "value" : "201"
+      } ],
+      "seriesData" : {
+        "metric" : "counter.kong.responses.count",
+        "regExStyle" : null
+      },
+      "transient" : false,
+      "type" : "plot",
+      "uniqueKey" : 1,
+      "yAxisIndex" : 0
+    }, {
+      "configuration" : {
+        "aliases" : { },
+        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
+        "maxExtrapolations" : -1
+      },
+      "dataManipulations" : [ ],
+      "invisible" : false,
+      "metricDefinition" : { },
+      "name" : "New Plot",
+      "queryItems" : [ ],
+      "seriesData" : { },
+      "transient" : true,
+      "type" : "plot",
+      "uniqueKey" : 18,
+      "yAxisIndex" : 0
+    } ],
+    "chartMode" : "graph",
+    "chartType" : "column",
+    "chartconfig" : {
+      "absoluteEnd" : null,
+      "absoluteStart" : null,
+      "colorByMetric" : false,
+      "colorByValue" : false,
+      "colorByValueScale" : [ ],
+      "groupBy" : [ ],
+      "heatmapAutoGradients" : 5,
+      "heatmapColorRange" : { },
+      "heatmapSortBy" : {
+        "asc" : true,
+        "value" : { }
+      },
+      "heatmapUnitsPerRow" : 0,
+      "heatmapUseValueAsColor" : false,
+      "hideTimestamp" : false,
+      "histogramColor" : "#ea1849",
+      "maxDecimalPlaces" : 4,
+      "range" : -300000,
+      "rangeEnd" : 0,
+      "secondaryVisualization" : "SPARKLINE",
+      "sortPreference" : "",
+      "stackedChart" : true,
+      "useKMG2" : false,
+      "yAxisConfigurations" : [ {
+        "id" : "yAxis0",
+        "label" : "errors/intvl",
+        "max" : null,
+        "min" : null,
+        "name" : "yAxis0",
+        "plotlines" : {
+          "high" : null,
+          "low" : null
+        }
+      } ]
+    },
+    "currentUniqueKey" : 19,
+    "relatedDetectors" : [ ],
+    "revisionNumber" : 27,
+    "uiHelperValue" : "##CHARTID##_27"
+  }
+}, {
+  "marshallId" : 70,
   "marshallMemberOf" : [ 59 ],
   "sf_chart" : "Response Size",
   "sf_chartIndex" : 1528139299895,
@@ -13918,7 +14581,7 @@
         "direction" : {
           "options" : {
             "aggregateGroupBy" : [ {
-              "value" : "route_id"
+              "value" : "api_name"
             } ],
             "collapseGroups" : false,
             "transformTimeRange" : null
@@ -13932,7 +14595,7 @@
         "showMe" : false
       } ],
       "invisible" : true,
-      "name" : "counter.kong.responses.size - Sum by route_id",
+      "name" : "counter.kong.responses.size - Sum by api_name",
       "queryItems" : [ {
         "NOT" : false,
         "iconClass" : "icon-properties",
@@ -13943,7 +14606,7 @@
       }, {
         "NOT" : false,
         "iconClass" : "icon-properties",
-        "property" : "route_id",
+        "property" : "api_name",
         "propertyValue" : "*",
         "type" : "property",
         "value" : "*"
@@ -13968,7 +14631,7 @@
         "direction" : {
           "options" : {
             "aggregateGroupBy" : [ {
-              "value" : "route_id"
+              "value" : "api_name"
             } ],
             "collapseGroups" : false,
             "transformTimeRange" : null
@@ -13983,7 +14646,7 @@
       } ],
       "invisible" : true,
       "metricDefinition" : { },
-      "name" : "counter.kong.responses.count - Sum by route_id",
+      "name" : "counter.kong.responses.count - Sum by api_name",
       "queryItems" : [ {
         "NOT" : false,
         "iconClass" : "icon-properties",
@@ -13994,7 +14657,7 @@
       }, {
         "NOT" : false,
         "iconClass" : "icon-properties",
-        "property" : "route_id",
+        "property" : "api_name",
         "propertyValue" : "*",
         "type" : "property",
         "value" : "*"
@@ -14215,613 +14878,7 @@
     },
     "currentUniqueKey" : 24,
     "relatedDetectors" : [ ],
-    "revisionNumber" : 42,
-    "uiHelperValue" : "##CHARTID##_42"
-  }
-}, {
-  "marshallId" : 68,
-  "marshallMemberOf" : [ 59 ],
-  "sf_chart" : "Request Size",
-  "sf_chartIndex" : 1528146664212,
-  "sf_description" : "Average size of Route-fielded client requests compared with -24h average",
-  "sf_type" : "Chart",
-  "sf_uiModel" : {
-    "allPlots" : [ {
-      "_originalLabel" : "K",
-      "configuration" : {
-        "aliases" : { },
-        "colorOverride" : null,
-        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
-        "maxExtrapolations" : -1,
-        "prefix" : "",
-        "rollupPolicy" : null,
-        "suffix" : "",
-        "unitType" : "Byte",
-        "visualization" : null
-      },
-      "dataManipulations" : [ {
-        "direction" : {
-          "options" : {
-            "aggregateGroupBy" : [ {
-              "value" : "route_id"
-            } ],
-            "collapseGroups" : false,
-            "transformTimeRange" : null
-          },
-          "type" : "aggregation"
-        },
-        "fn" : {
-          "options" : { },
-          "type" : "SUM"
-        },
-        "showMe" : false
-      } ],
-      "invisible" : true,
-      "name" : "counter.kong.requests.size - Sum by route_id",
-      "queryItems" : [ {
-        "NOT" : false,
-        "iconClass" : "icon-properties",
-        "property" : "plugin",
-        "propertyValue" : "kong",
-        "type" : "property",
-        "value" : "kong"
-      }, {
-        "NOT" : false,
-        "iconClass" : "icon-properties",
-        "property" : "route_id",
-        "propertyValue" : "*",
-        "type" : "property",
-        "value" : "*"
-      } ],
-      "seriesData" : {
-        "metric" : "counter.kong.requests.size",
-        "regExStyle" : null
-      },
-      "transient" : false,
-      "type" : "plot",
-      "uniqueKey" : 11,
-      "yAxisIndex" : 0
-    }, {
-      "_originalLabel" : "L",
-      "configuration" : {
-        "aliases" : { },
-        "colorOverride" : null,
-        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
-        "maxExtrapolations" : -1,
-        "prefix" : "",
-        "rollupPolicy" : null,
-        "suffix" : "",
-        "unitType" : "Byte"
-      },
-      "dataManipulations" : [ {
-        "direction" : {
-          "options" : {
-            "aggregateGroupBy" : [ {
-              "value" : "route_id"
-            } ],
-            "collapseGroups" : false,
-            "transformTimeRange" : null
-          },
-          "type" : "aggregation"
-        },
-        "fn" : {
-          "options" : { },
-          "type" : "SUM"
-        },
-        "showMe" : false
-      } ],
-      "invisible" : true,
-      "name" : "counter.kong.responses.count - Sum by route_id",
-      "queryItems" : [ {
-        "NOT" : false,
-        "iconClass" : "icon-properties",
-        "property" : "plugin",
-        "propertyValue" : "kong",
-        "type" : "property",
-        "value" : "kong"
-      }, {
-        "NOT" : false,
-        "iconClass" : "icon-properties",
-        "property" : "route_id",
-        "propertyValue" : "*",
-        "type" : "property",
-        "value" : "*"
-      } ],
-      "seriesData" : {
-        "metric" : "counter.kong.responses.count",
-        "regExStyle" : null
-      },
-      "transient" : false,
-      "type" : "plot",
-      "uniqueKey" : 12,
-      "yAxisIndex" : 0
-    }, {
-      "_originalLabel" : "M",
-      "configuration" : {
-        "aliases" : { },
-        "colorOverride" : null,
-        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
-        "maxExtrapolations" : -1,
-        "prefix" : "",
-        "suffix" : "",
-        "unitType" : "Byte"
-      },
-      "dataManipulations" : [ ],
-      "expressionText" : "K/L",
-      "invisible" : false,
-      "metricDefinition" : { },
-      "name" : "request size",
-      "queryItems" : [ ],
-      "seriesData" : {
-        "metric" : null
-      },
-      "transient" : false,
-      "type" : "ratio",
-      "uniqueKey" : 13,
-      "valid" : true,
-      "yAxisIndex" : 0
-    }, {
-      "_originalLabel" : "P",
-      "configuration" : {
-        "aliases" : { },
-        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
-        "maxExtrapolations" : -1
-      },
-      "dataManipulations" : [ {
-        "direction" : {
-          "options" : {
-            "aggregateGroupBy" : [ ],
-            "collapseGroups" : false,
-            "transformTimeRange" : null
-          },
-          "type" : "aggregation"
-        },
-        "fn" : {
-          "options" : { },
-          "type" : "SUM"
-        },
-        "showMe" : false
-      } ],
-      "expressionText" : "K",
-      "invisible" : true,
-      "metricDefinition" : { },
-      "name" : "K - Sum",
-      "queryItems" : [ ],
-      "seriesData" : {
-        "metric" : null
-      },
-      "transient" : false,
-      "type" : "ratio",
-      "uniqueKey" : 16,
-      "valid" : true,
-      "yAxisIndex" : 0
-    }, {
-      "_originalLabel" : "Q",
-      "configuration" : {
-        "aliases" : { },
-        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
-        "maxExtrapolations" : -1
-      },
-      "dataManipulations" : [ {
-        "direction" : {
-          "options" : {
-            "aggregateGroupBy" : [ ],
-            "collapseGroups" : false,
-            "transformTimeRange" : null
-          },
-          "type" : "aggregation"
-        },
-        "fn" : {
-          "options" : { },
-          "type" : "SUM"
-        },
-        "showMe" : false
-      } ],
-      "expressionText" : "L",
-      "invisible" : true,
-      "metricDefinition" : { },
-      "name" : "L - Sum",
-      "queryItems" : [ ],
-      "seriesData" : {
-        "metric" : null
-      },
-      "transient" : false,
-      "type" : "ratio",
-      "uniqueKey" : 17,
-      "valid" : true,
-      "yAxisIndex" : 0
-    }, {
-      "_originalLabel" : "R",
-      "configuration" : {
-        "aliases" : { },
-        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
-        "maxExtrapolations" : -1,
-        "prefix" : "",
-        "suffix" : "",
-        "unitType" : "Byte",
-        "visualization" : "line"
-      },
-      "dataManipulations" : [ {
-        "direction" : {
-          "options" : {
-            "aggregateGroupBy" : [ ],
-            "collapseGroups" : false,
-            "transformTimeRange" : null
-          },
-          "type" : "aggregation"
-        },
-        "fn" : {
-          "options" : {
-            "milliseconds" : 86400000
-          },
-          "type" : "TIMESHIFT"
-        },
-        "showMe" : false
-      } ],
-      "expressionText" : "P/Q",
-      "invisible" : false,
-      "metricDefinition" : { },
-      "name" : "request size (historic)",
-      "queryItems" : [ ],
-      "seriesData" : {
-        "metric" : null
-      },
-      "transient" : false,
-      "type" : "ratio",
-      "uniqueKey" : 18,
-      "valid" : true,
-      "yAxisIndex" : 1
-    }, {
-      "configuration" : {
-        "aliases" : { },
-        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
-        "maxExtrapolations" : -1
-      },
-      "dataManipulations" : [ ],
-      "invisible" : false,
-      "metricDefinition" : { },
-      "name" : "New Plot",
-      "queryItems" : [ ],
-      "seriesData" : { },
-      "transient" : true,
-      "type" : "plot",
-      "uniqueKey" : 19,
-      "yAxisIndex" : 0
-    } ],
-    "chartMode" : "graph",
-    "chartType" : "heatmap",
-    "chartconfig" : {
-      "absoluteEnd" : null,
-      "absoluteStart" : null,
-      "colorByMetric" : false,
-      "colorByValue" : false,
-      "colorByValueScale" : [ ],
-      "dimensionInLegend" : "sf_metric",
-      "eventLines" : false,
-      "histogramColor" : "#0dba8f",
-      "includeZero" : false,
-      "range" : -1800000,
-      "rangeEnd" : 0,
-      "secondaryVisualization" : "SPARKLINE",
-      "showLegend" : false,
-      "sortPreference" : "-value",
-      "useKMG2" : false,
-      "yAxisConfigurations" : [ {
-        "id" : "yAxis0",
-        "label" : "bytes/req",
-        "max" : null,
-        "min" : null,
-        "name" : "yAxis0",
-        "plotlines" : {
-          "high" : null,
-          "low" : null
-        }
-      }, {
-        "label" : "bytes/req",
-        "max" : null,
-        "min" : null,
-        "plotlines" : {
-          "high" : null,
-          "low" : null
-        },
-        "title" : {
-          "text" : ""
-        }
-      } ]
-    },
-    "currentUniqueKey" : 20,
-    "relatedDetectors" : [ ],
-    "revisionNumber" : 35,
-    "uiHelperValue" : "##CHARTID##_35"
-  }
-}, {
-  "marshallId" : 69,
-  "marshallMemberOf" : [ 59 ],
-  "sf_chart" : "Responses / Second",
-  "sf_chartIndex" : 1528219376990,
-  "sf_description" : "Rate of upstream responses compared with -24h",
-  "sf_type" : "Chart",
-  "sf_uiModel" : {
-    "allPlots" : [ {
-      "_originalLabel" : "B",
-      "configuration" : {
-        "aliases" : { },
-        "colorOverride" : null,
-        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
-        "maxExtrapolations" : -1,
-        "prefix" : "",
-        "suffix" : "responses",
-        "unitType" : null
-      },
-      "dataManipulations" : [ {
-        "direction" : {
-          "options" : {
-            "aggregateGroupBy" : [ {
-              "value" : "route_id"
-            } ],
-            "collapseGroups" : false,
-            "transformTimeRange" : null
-          },
-          "type" : "aggregation"
-        },
-        "fn" : {
-          "options" : { },
-          "type" : "SUM"
-        },
-        "showMe" : false
-      } ],
-      "invisible" : false,
-      "name" : "",
-      "queryItems" : [ {
-        "NOT" : false,
-        "iconClass" : "sf-icon-property",
-        "property" : "plugin",
-        "propertyValue" : "kong",
-        "query" : "plugin:\"kong\"",
-        "type" : "property",
-        "value" : "kong"
-      }, {
-        "NOT" : false,
-        "iconClass" : "icon-properties",
-        "property" : "route_id",
-        "propertyValue" : "*",
-        "type" : "property",
-        "value" : "*"
-      } ],
-      "seriesData" : {
-        "metric" : "counter.kong.responses.count"
-      },
-      "transient" : false,
-      "type" : "plot",
-      "uniqueKey" : 2,
-      "yAxisIndex" : 0
-    }, {
-      "_originalLabel" : "C",
-      "configuration" : {
-        "aliases" : { },
-        "colorOverride" : "#b04600",
-        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
-        "maxExtrapolations" : -1,
-        "suffix" : "responses",
-        "unitType" : null,
-        "visualization" : "line"
-      },
-      "dataManipulations" : [ {
-        "direction" : {
-          "options" : {
-            "aggregateGroupBy" : [ ],
-            "collapseGroups" : false,
-            "transformTimeRange" : null
-          },
-          "type" : "aggregation"
-        },
-        "fn" : {
-          "options" : { },
-          "type" : "SUM"
-        },
-        "showMe" : false
-      }, {
-        "direction" : {
-          "options" : {
-            "aggregateGroupBy" : [ ],
-            "collapseGroups" : false,
-            "transformTimeRange" : null
-          },
-          "type" : "aggregation"
-        },
-        "fn" : {
-          "options" : {
-            "milliseconds" : 86400000
-          },
-          "type" : "TIMESHIFT"
-        },
-        "showMe" : false
-      } ],
-      "expressionText" : "B",
-      "invisible" : false,
-      "metricDefinition" : { },
-      "name" : "(historic)",
-      "queryItems" : [ ],
-      "seriesData" : {
-        "metric" : null
-      },
-      "transient" : false,
-      "type" : "ratio",
-      "uniqueKey" : 3,
-      "valid" : true,
-      "yAxisIndex" : 1
-    }, {
-      "configuration" : {
-        "aliases" : { },
-        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
-        "maxExtrapolations" : -1
-      },
-      "dataManipulations" : [ ],
-      "invisible" : false,
-      "metricDefinition" : { },
-      "name" : "New Plot",
-      "queryItems" : [ ],
-      "seriesData" : { },
-      "transient" : true,
-      "type" : "plot",
-      "uniqueKey" : 4,
-      "yAxisIndex" : 0
-    } ],
-    "chartMode" : "graph",
-    "chartType" : "area",
-    "chartconfig" : {
-      "absoluteEnd" : null,
-      "absoluteStart" : null,
-      "colorByMetric" : false,
-      "colorByValue" : false,
-      "colorByValueScale" : [ ],
-      "dimensionInLegend" : "api_name",
-      "hideTimestamp" : false,
-      "histogramColor" : "#ea1849",
-      "maxDecimalPlaces" : 2,
-      "range" : -1800000,
-      "rangeEnd" : 0,
-      "secondaryVisualization" : "NONE",
-      "showLegend" : false,
-      "sortPreference" : "",
-      "stackedChart" : true,
-      "useKMG2" : false,
-      "yAxisConfigurations" : [ {
-        "id" : "yAxis0",
-        "label" : "resp/s",
-        "max" : null,
-        "min" : null,
-        "name" : "yAxis0",
-        "plotlines" : {
-          "high" : null,
-          "low" : null
-        }
-      }, {
-        "label" : "resp/s",
-        "max" : null,
-        "min" : null,
-        "plotlines" : {
-          "high" : null,
-          "low" : null
-        },
-        "title" : {
-          "text" : ""
-        }
-      } ]
-    },
-    "currentUniqueKey" : 5,
-    "relatedDetectors" : [ ],
     "revisionNumber" : 38,
     "uiHelperValue" : "##CHARTID##_38"
-  }
-}, {
-  "marshallId" : 70,
-  "marshallMemberOf" : [ 59 ],
-  "sf_chart" : "Requests by HTTP Method",
-  "sf_chartIndex" : 1528138165800,
-  "sf_description" : "Number of Route-fielded requests per interval by HTTP method",
-  "sf_type" : "Chart",
-  "sf_uiModel" : {
-    "allPlots" : [ {
-      "_originalLabel" : "A",
-      "configuration" : {
-        "aliases" : { },
-        "colorOverride" : null,
-        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
-        "maxExtrapolations" : -1,
-        "rollupPolicy" : "DELTA_ROLLUP",
-        "suffix" : "requests",
-        "unitType" : null
-      },
-      "dataManipulations" : [ {
-        "direction" : {
-          "options" : {
-            "aggregateGroupBy" : [ {
-              "value" : "http_method"
-            } ],
-            "collapseGroups" : false,
-            "transformTimeRange" : null
-          },
-          "type" : "aggregation"
-        },
-        "fn" : {
-          "options" : { },
-          "type" : "SUM"
-        },
-        "showMe" : false
-      } ],
-      "invisible" : false,
-      "name" : "",
-      "queryItems" : [ {
-        "NOT" : false,
-        "iconClass" : "icon-properties",
-        "property" : "plugin",
-        "propertyValue" : "kong",
-        "type" : "property",
-        "value" : "kong"
-      }, {
-        "NOT" : false,
-        "iconClass" : "icon-properties",
-        "property" : "route_id",
-        "propertyValue" : "*",
-        "type" : "property",
-        "value" : "*"
-      } ],
-      "seriesData" : {
-        "metric" : "counter.kong.responses.count"
-      },
-      "transient" : false,
-      "type" : "plot",
-      "uniqueKey" : 1,
-      "yAxisIndex" : 0
-    }, {
-      "configuration" : {
-        "aliases" : { },
-        "extrapolationPolicy" : "NULL_EXTRAPOLATION",
-        "maxExtrapolations" : -1
-      },
-      "dataManipulations" : [ ],
-      "invisible" : false,
-      "metricDefinition" : { },
-      "name" : "New Plot",
-      "queryItems" : [ ],
-      "seriesData" : { },
-      "transient" : true,
-      "type" : "plot",
-      "uniqueKey" : 18,
-      "yAxisIndex" : 0
-    } ],
-    "chartMode" : "graph",
-    "chartType" : "column",
-    "chartconfig" : {
-      "absoluteEnd" : null,
-      "absoluteStart" : null,
-      "colorByMetric" : false,
-      "colorByValue" : false,
-      "colorByValueScale" : [ ],
-      "histogramColor" : "#ea1849",
-      "maxDecimalPlaces" : 4,
-      "range" : -1800000,
-      "rangeEnd" : 0,
-      "secondaryVisualization" : "SPARKLINE",
-      "sortPreference" : "+http_method",
-      "stackedChart" : true,
-      "useKMG2" : false,
-      "yAxisConfigurations" : [ {
-        "id" : "yAxis0",
-        "label" : "req/intvl",
-        "max" : null,
-        "min" : null,
-        "name" : "yAxis0",
-        "plotlines" : {
-          "high" : null,
-          "low" : null
-        }
-      } ]
-    },
-    "currentUniqueKey" : 19,
-    "relatedDetectors" : [ ],
-    "revisionNumber" : 29,
-    "uiHelperValue" : "##CHARTID##_29"
   }
 } ]


### PR DESCRIPTION
Before this would display negative numbers upon cumulative resets.